### PR TITLE
SOL-28 sprite rendering enhancements

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@ int main(void) {
   auto logger = spdlog::basic_logger_mt("solcorp", "./solcorp.log", true);
   spdlog::set_default_logger(logger);
   logger->set_level(spdlog::level::debug);
-  logger->flush_on(spdlog::level::info);
+  logger->flush_on(spdlog::level::debug);
 
   flecs::world world;
 
@@ -39,40 +39,68 @@ int main(void) {
   world.import <RocketLaunchModule>();
   world.import <StaffModule>();
 
-  auto site = world.entity("Cape Canaveral")
-                  .set<Site>({10, 10})
-                  .set<Transform>({{0, 50}, {}});
-  world.entity("Storage Hall 1")
-      .add<Building>()
-      .set<Storage>({})
-      .set<SiteLocation>({0, 0})
-      .set<Transform>({{0, 0}, {}})
-      .set<Sprite>({"building_texture", 2})
-      .child_of(site);
-  world.entity("Launchpad")
-      .add<Building>()
-      .set<Launchpad>({})
-      .set<SiteLocation>({1, 0})
-      .set<Transform>({{32, 0}, {}})
-      .set<Sprite>({"building_texture", 3})
-      .child_of(site);
-  world.entity("North Building")
-      .add<Building>()
-      .set<Office>({})
-      .set<SiteLocation>({2, 0})
-      .set<Transform>({{64, 0}, {}})
-      .set<Sprite>({"building_texture", 1})
-      .child_of(site);
-  auto e = world.entity("Manufacturing A")
-               .add<Building>()
-               .set<Manufacturing>({})
-               .set<Storage>({})
-               .set<SiteLocation>({1, 1})
-               .set<Transform>({{32, 32}, {}})
-               .set<Sprite>({"building_texture", 2})
-               .child_of(site);
-  e.get_mut<Manufacturing>()->lines.push_back(flecs::entity());
-  e.get_mut<Manufacturing>()->lines.push_back(flecs::entity());
+  world.system("Load Textures")
+      .kind(flecs::OnStart)
+      .immediate()
+      .run([](flecs::iter &iter) {
+        spdlog::debug("Loading textures");
+        auto world = iter.world();
+        auto root = world.entity("Textures");
+
+        Texture t = loadTexture("textures/solcorp_buildings.png", world);
+        t.cols = 1;
+        t.rows = 4;
+        auto b = world.entity("Buildings").set<Texture>(t).child_of(root);
+
+        spdlog::error("b is Textures::Buildings = {}",
+                      world.lookup("Textures::Buildings") == b);
+      });
+
+  world.system("Site Creation")
+      .kind(flecs::OnStart)
+      .immediate()
+      .run([](flecs::iter &iter) {
+        spdlog::debug("Setting up buildings");
+
+        auto world = iter.world();
+
+        auto site = world.entity("Cape Canaveral")
+                        .set<Site>({10, 10})
+                        .set<Transform>({{0, 50}, {}});
+        world.entity("Storage Hall 1")
+            .add<Building>()
+            .set<Storage>({})
+            .set<SiteLocation>({0, 0})
+            .set<Transform>({{0, 0}, {}})
+            .set<Sprite>(spriteFromTileMap(world, "Buildings", 2))
+            .child_of(site);
+        world.entity("Launchpad")
+            .add<Building>()
+            .set<Launchpad>({})
+            .set<SiteLocation>({1, 0})
+            .set<Transform>({{32, 0}, {}})
+            .set<Sprite>(spriteFromTileMap(world, "Buildings", 3))
+            .child_of(site);
+        world.entity("North Building")
+            .add<Building>()
+            .set<Office>({})
+            .set<SiteLocation>({2, 0})
+            .set<Transform>({{64, 0}, {}})
+            .set<Sprite>(spriteFromTileMap(world, "Buildings", 1))
+            .child_of(site);
+
+        Manufacturing m;
+        m.lines.push_back(flecs::entity());
+        m.lines.push_back(flecs::entity());
+        world.entity("Manufacturing A")
+            .add<Building>()
+            .set<Manufacturing>(m)
+            .set<Storage>({})
+            .set<SiteLocation>({1, 1})
+            .set<Transform>({{32, 32}, {}})
+            .set<Sprite>(spriteFromTileMap(world, "Buildings", 2))
+            .child_of(site);
+      });
 
   // Main Loop
   logger->info("Starting");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,3 @@
-
 #include "modules/gui/gui.h"
 #include "modules/input/input.h"
 #include "modules/main_menu/main_menu.h"
@@ -47,13 +46,19 @@ int main(void) {
         auto world = iter.world();
         auto root = world.entity("Textures");
 
-        Texture t = loadTexture("textures/solcorp_buildings.png", world);
-        t.cols = 1;
-        t.rows = 4;
-        auto b = world.entity("Buildings").set<Texture>(t).child_of(root);
+        world.entity("Buildings")
+            .set<Texture>(loadTexture("textures/solcorp_buildings.png", world))
+            .child_of(root);
+      });
 
-        spdlog::error("b is Textures::Buildings = {}",
-                      world.lookup("Textures::Buildings") == b);
+  world.system("TileMap Creation")
+      .kind(flecs::OnStart)
+      .immediate()
+      .run([](flecs::iter &iter) {
+        auto world = iter.world();
+        auto texture = world.lookup("Textures::Buildings");
+
+        world.entity("BuildingTileMap").set<TileMap>({texture, 1, 4});
       });
 
   world.system("Site Creation")
@@ -63,6 +68,7 @@ int main(void) {
         spdlog::debug("Setting up buildings");
 
         auto world = iter.world();
+        auto tm = world.lookup("BuildingTileMap");
 
         auto site = world.entity("Cape Canaveral")
                         .set<Site>({10, 10})
@@ -72,33 +78,29 @@ int main(void) {
             .set<Storage>({})
             .set<SiteLocation>({0, 0})
             .set<Transform>({{0, 0}, {}})
-            .set<Sprite>(spriteFromTileMap(world, "Buildings", 2))
+            .set<Sprite>(spriteFromTileMap(tm, 2))
             .child_of(site);
         world.entity("Launchpad")
             .add<Building>()
             .set<Launchpad>({})
             .set<SiteLocation>({1, 0})
             .set<Transform>({{32, 0}, {}})
-            .set<Sprite>(spriteFromTileMap(world, "Buildings", 3))
+            .set<Sprite>(spriteFromTileMap(tm, 3))
             .child_of(site);
         world.entity("North Building")
             .add<Building>()
             .set<Office>({})
             .set<SiteLocation>({2, 0})
             .set<Transform>({{64, 0}, {}})
-            .set<Sprite>(spriteFromTileMap(world, "Buildings", 1))
+            .set<Sprite>(spriteFromTileMap(tm, 1))
             .child_of(site);
-
-        Manufacturing m;
-        m.lines.push_back(flecs::entity());
-        m.lines.push_back(flecs::entity());
         world.entity("Manufacturing A")
             .add<Building>()
-            .set<Manufacturing>(m)
+            .emplace<Manufacturing>(Manufacturing(2))
             .set<Storage>({})
             .set<SiteLocation>({1, 1})
             .set<Transform>({{32, 32}, {}})
-            .set<Sprite>(spriteFromTileMap(world, "Buildings", 2))
+            .set<Sprite>(spriteFromTileMap(tm, 2))
             .child_of(site);
       });
 

--- a/src/modules/render/render.cpp
+++ b/src/modules/render/render.cpp
@@ -1,5 +1,6 @@
 #include "render.h"
 #include "SDL_render.h"
+#include "flecs/addons/cpp/entity.hpp"
 #include "modules/phase/phase.h"
 #include "spdlog/spdlog.h"
 #include <SDL2/SDL.h>
@@ -15,10 +16,8 @@ void systemRenderClear(const Renderer &);
 void systemRenderPresent(const Renderer &r);
 void systemRenderSprite(flecs::entity, const Sprite &, const Transform &,
                         const Renderer &);
-SDL_Rect clipTileFromTexture(const Texture *, int);
 
 RenderModule::RenderModule(flecs::world &world) {
-
   world.import <PhaseModule>();
 
   initialiseGraphics(world);
@@ -32,9 +31,11 @@ RenderModule::RenderModule(flecs::world &world) {
   world.component<Texture>()
       .member<size_t>("ptr")
       .member<int>("width")
-      .member<int>("height")
-      .member<unsigned int>("rows")
-      .member<unsigned int>("cols");
+      .member<int>("height");
+  world.component<TileMap>()
+      .member<flecs::entity>("texture")
+      .member<unsigned int>("cols")
+      .member<unsigned int>("rows");
   world.component<Sprite>()
       .member<flecs::entity>("texture")
       .member<int>("tile")
@@ -155,38 +156,22 @@ void systemRenderSprite(flecs::entity, const Sprite &sprite,
   SDL_RenderCopy(renderer.renderer, t->ptr, &source, &destination);
 }
 
-/// @brief Extracts a n*n tile rect from a tilemap
-/// @param texture A pointer to the texture to use
-/// @param tile The tile (number wraps at row-end)
-/// @returns An SDL_Rect with the co-ordinates to clip from
-SDL_Rect clipTileFromTexture(const Texture *texture, int tile) {
-  int tileSize = texture->width / texture->cols;
-  int tileCol = tile % texture->cols;
-  int tileRow = (tile - (tileCol)) / texture->cols;
-
-  SDL_Rect source = {tileCol * tileSize, tileRow * tileSize, tileSize,
-                     tileSize};
-  return source;
-}
-
 /// @brief Extracts a tile from a tilemap and generates a Sprite component
 /// @param[in] world The flecs world
 /// @param[in] textureName The name of the texture
 /// @param[in] tile The tile number (number wraps at row-end)
 /// @returns An Sprite with the co-ordinates to clip tile from in the texture
-Sprite spriteFromTileMap(flecs::world world, std::string textureName,
-                         int tile) {
-  auto root = world.lookup("Textures");
-  auto entity = root.lookup(textureName.c_str());
-  auto texture = entity.get<Texture>();
+Sprite spriteFromTileMap(flecs::entity tileMapE, int tile) {
+  auto tileMap = tileMapE.get<TileMap>();
+  auto texture = tileMap->texture.get<Texture>();
 
-  int tileWidth = texture->width / texture->cols;
-  int tileHeight = texture->height / texture->rows;
-  int tileCol = tile % texture->cols;
-  int tileRow = (tile - (tileCol)) / texture->cols;
+  int tileWidth = texture->width / tileMap->cols;
+  int tileHeight = texture->height / tileMap->rows;
+  int tileCol = tile % tileMap->cols;
+  int tileRow = (tile - (tileCol)) / tileMap->cols;
 
   Sprite sprite;
-  sprite.texture = entity;
+  sprite.texture = tileMap->texture;
   sprite.x = tileCol * tileWidth;
   sprite.y = tileRow * tileHeight;
   sprite.width = tileWidth;

--- a/src/modules/render/render.cpp
+++ b/src/modules/render/render.cpp
@@ -152,13 +152,14 @@ void systemRenderPresent(const Renderer &r) { SDL_RenderPresent(r.renderer); }
 void systemRenderSprite(flecs::entity, const Sprite &sprite,
                         const Transform &target, const Renderer &renderer) {
   SDL_Rect source = {sprite.x, sprite.y, sprite.width, sprite.height};
-  SDL_Rect destination = {target.worldPosition.x, target.worldPosition.y,
-                          sprite.width, sprite.height};
+  SDL_FRect destination = {
+      target.worldPosition.x * 1.0f, target.worldPosition.y * 1.0f,
+      sprite.width * sprite.scale, sprite.height * sprite.scale};
   auto t = sprite.texture.get<Texture>();
 
-  SDL_RenderCopyEx(renderer.renderer, t->ptr, &source, &destination,
-                   sprite.rotation, NULL,
-                   static_cast<SDL_RendererFlip>(sprite.flip));
+  SDL_RenderCopyExF(renderer.renderer, t->ptr, &source, &destination,
+                    sprite.rotation, NULL,
+                    static_cast<SDL_RendererFlip>(sprite.flip));
 }
 
 /// @brief Extracts a tile from a tilemap and generates a Sprite component

--- a/src/modules/render/render.cpp
+++ b/src/modules/render/render.cpp
@@ -42,7 +42,9 @@ RenderModule::RenderModule(flecs::world &world) {
       .member<int>("x")
       .member<int>("y")
       .member<int>("width")
-      .member<int>("height");
+      .member<int>("height")
+      .member<double>("rotation")
+      .member<int>("flip");
 
   // Register systems
   world.system<Transform, const Transform *>("Apply Parent Transform")
@@ -153,7 +155,10 @@ void systemRenderSprite(flecs::entity, const Sprite &sprite,
   SDL_Rect destination = {target.worldPosition.x, target.worldPosition.y,
                           sprite.width, sprite.height};
   auto t = sprite.texture.get<Texture>();
-  SDL_RenderCopy(renderer.renderer, t->ptr, &source, &destination);
+
+  SDL_RenderCopyEx(renderer.renderer, t->ptr, &source, &destination,
+                   sprite.rotation, NULL,
+                   static_cast<SDL_RendererFlip>(sprite.flip));
 }
 
 /// @brief Extracts a tile from a tilemap and generates a Sprite component

--- a/src/modules/render/render.cpp
+++ b/src/modules/render/render.cpp
@@ -1,21 +1,21 @@
 #include "render.h"
+#include "SDL_render.h"
 #include "modules/phase/phase.h"
 #include "spdlog/spdlog.h"
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 #include <SDL_ttf.h>
+#include <cstddef>
 #include <cstdlib>
 #include <flecs.h>
 
 void initialiseGraphics(flecs::world &);
 void systemApplyParentTransform(Transform &t, const Transform *parent);
-void systemLoadTextures(flecs::iter &);
 void systemRenderClear(const Renderer &);
 void systemRenderPresent(const Renderer &r);
 void systemRenderSprite(flecs::entity, const Sprite &, const Transform &,
                         const Renderer &);
 SDL_Rect clipTileFromTexture(const Texture *, int);
-Texture loadTexture(const std::string &, flecs::world &);
 
 RenderModule::RenderModule(flecs::world &world) {
 
@@ -29,12 +29,21 @@ RenderModule::RenderModule(flecs::world &world) {
       .member<Point>("relativePosition")
       .member<Point>("worldPosition");
   world.component<Renderer>();
-  world.component<Texture>();
-  world.component<Sprite>().member<std::string>("texture").member<int>("tile");
+  world.component<Texture>()
+      .member<size_t>("ptr")
+      .member<int>("width")
+      .member<int>("height")
+      .member<unsigned int>("rows")
+      .member<unsigned int>("cols");
+  world.component<Sprite>()
+      .member<flecs::entity>("texture")
+      .member<int>("tile")
+      .member<int>("x")
+      .member<int>("y")
+      .member<int>("width")
+      .member<int>("height");
 
   // Register systems
-  world.system("Load Textures").kind(flecs::OnStart).run(systemLoadTextures);
-
   world.system<Transform, const Transform *>("Apply Parent Transform")
       .term_at(1)
       .parent()
@@ -124,17 +133,6 @@ void systemApplyParentTransform(Transform &t, const Transform *parent) {
   }
 }
 
-/// @brief Initialises the Renderer and Window
-/// @param iter Access to flecs world
-void systemLoadTextures(flecs::iter &iter) {
-  auto world = iter.world();
-
-  Texture t = loadTexture("textures/solcorp_buildings.png", world);
-  t.cols = 1;
-  t.rows = 4;
-  world.entity("building_texture").set<Texture>(t);
-}
-
 /// @brief System that clears the screen before a frame update
 /// @param renderer The Render Component Singleton
 void systemRenderClear(const Renderer &r) { SDL_RenderClear(r.renderer); }
@@ -148,17 +146,13 @@ void systemRenderPresent(const Renderer &r) { SDL_RenderPresent(r.renderer); }
 /// @param sprite Sprite information to render
 /// @param target Where on screen to render the sprite
 /// @param renderer The renderer used to draw on the screen
-void systemRenderSprite(flecs::entity e, const Sprite &sprite,
+void systemRenderSprite(flecs::entity, const Sprite &sprite,
                         const Transform &target, const Renderer &renderer) {
-  const u_int tileSize = 32;
-  auto texture = e.world().lookup(sprite.texture.c_str()).get<Texture>();
-  int target_x = static_cast<int>(target.worldPosition.x);
-  int target_y = static_cast<int>(target.worldPosition.y);
-  SDL_Rect source = clipTileFromTexture(texture, sprite.tile);
-  SDL_Rect destination = {target_x, target_y, tileSize, tileSize};
-
-  // SDL_SetTextureColorMod(spite.texture, fg.Red(), fg.Green(), fg.Blue());
-  SDL_RenderCopy(renderer.renderer, texture->ptr, &source, &destination);
+  SDL_Rect source = {sprite.x, sprite.y, sprite.width, sprite.height};
+  SDL_Rect destination = {target.worldPosition.x, target.worldPosition.y,
+                          sprite.width, sprite.height};
+  auto t = sprite.texture.get<Texture>();
+  SDL_RenderCopy(renderer.renderer, t->ptr, &source, &destination);
 }
 
 /// @brief Extracts a n*n tile rect from a tilemap
@@ -175,6 +169,32 @@ SDL_Rect clipTileFromTexture(const Texture *texture, int tile) {
   return source;
 }
 
+/// @brief Extracts a tile from a tilemap and generates a Sprite component
+/// @param[in] world The flecs world
+/// @param[in] textureName The name of the texture
+/// @param[in] tile The tile number (number wraps at row-end)
+/// @returns An Sprite with the co-ordinates to clip tile from in the texture
+Sprite spriteFromTileMap(flecs::world world, std::string textureName,
+                         int tile) {
+  auto root = world.lookup("Textures");
+  auto entity = root.lookup(textureName.c_str());
+  auto texture = entity.get<Texture>();
+
+  int tileWidth = texture->width / texture->cols;
+  int tileHeight = texture->height / texture->rows;
+  int tileCol = tile % texture->cols;
+  int tileRow = (tile - (tileCol)) / texture->cols;
+
+  Sprite sprite;
+  sprite.texture = entity;
+  sprite.x = tileCol * tileWidth;
+  sprite.y = tileRow * tileHeight;
+  sprite.width = tileWidth;
+  sprite.height = tileHeight;
+
+  return sprite;
+}
+
 /// @brief Loads the given texture into a Texture component
 /// @param name The filename (including directory) to load
 /// @param world The flecs world to interact with
@@ -182,30 +202,13 @@ SDL_Rect clipTileFromTexture(const Texture *texture, int tile) {
 Texture loadTexture(const std::string &filename, flecs::world &world) {
   Texture texture;
   const Renderer *r = world.get<Renderer>();
-
-  // Load image at specified path
-  SDL_Surface *surface = IMG_Load(filename.c_str());
-  if (surface == nullptr) {
-    spdlog::error("Unable to load image {} SDL_image Error: {}", filename,
-                  IMG_GetError());
-    throw std::runtime_error("Failed to load texture");
-  }
-  auto magenta = SDL_MapRGB(surface->format, 255, 0, 255);
-  SDL_SetColorKey(surface, SDL_TRUE, magenta); // Make it transparent
-  texture.width = surface->w;
-  texture.height = surface->h;
-
-  // Create texture from surface pixels
-  texture.ptr = SDL_CreateTextureFromSurface(r->renderer, surface);
+  texture.ptr = IMG_LoadTexture(r->renderer, filename.c_str());
   if (texture.ptr == nullptr) {
     spdlog::error("Unable to create texture from surface. SDL Error: {}",
                   SDL_GetError());
     throw std::runtime_error("Failed to create texture from surface");
   }
-  // SDL_SetTextureBlendMode(texture.ptr, SDL_BLENDMODE_BLEND);
-
-  // Get rid of old loaded surface
-  SDL_FreeSurface(surface);
+  SDL_QueryTexture(texture.ptr, NULL, NULL, &texture.width, &texture.height);
 
   return texture;
 }

--- a/src/modules/render/render.h
+++ b/src/modules/render/render.h
@@ -33,9 +33,16 @@ struct Texture {
 };
 
 struct Sprite {
-  std::string texture;
+  flecs::entity texture;
   int tile = 0;
+  int x = 0;
+  int y = 0;
+  int width = 0;
+  int height = 0;
 };
+
+Texture loadTexture(const std::string &, flecs::world &);
+Sprite spriteFromTileMap(flecs::world, std::string, int);
 
 struct RenderModule {
 public:

--- a/src/modules/render/render.h
+++ b/src/modules/render/render.h
@@ -36,6 +36,12 @@ struct TileMap {
   unsigned int rows = 0;
 };
 
+enum SpriteFlip {
+  None = 0,
+  Horizontal = 1,
+  Vertical = 2,
+};
+
 struct Sprite {
   flecs::entity texture;
   int tile = 0;
@@ -43,6 +49,8 @@ struct Sprite {
   int y = 0;
   int width = 0;
   int height = 0;
+  double rotation = 0.0f;
+  SpriteFlip flip = SpriteFlip::None;
 };
 
 Texture loadTexture(const std::string &, flecs::world &);

--- a/src/modules/render/render.h
+++ b/src/modules/render/render.h
@@ -49,6 +49,7 @@ struct Sprite {
   int y = 0;
   int width = 0;
   int height = 0;
+  float scale = 1.0f;
   double rotation = 0.0f;
   SpriteFlip flip = SpriteFlip::None;
 };

--- a/src/modules/render/render.h
+++ b/src/modules/render/render.h
@@ -28,8 +28,12 @@ struct Texture {
   SDL_Texture *ptr = nullptr;
   int width = 0;
   int height = 0;
-  unsigned int rows = 0;
+};
+
+struct TileMap {
+  flecs::entity texture;
   unsigned int cols = 0;
+  unsigned int rows = 0;
 };
 
 struct Sprite {
@@ -42,7 +46,7 @@ struct Sprite {
 };
 
 Texture loadTexture(const std::string &, flecs::world &);
-Sprite spriteFromTileMap(flecs::world, std::string, int);
+Sprite spriteFromTileMap(flecs::entity tileMapE, int tile);
 
 struct RenderModule {
 public:

--- a/src/modules/site/site.h
+++ b/src/modules/site/site.h
@@ -23,10 +23,11 @@ struct SiteLocation {
 
 /// @brief Allows construction of rockets
 struct Manufacturing {
-  u_int maxLines = 1;
   std::vector<flecs::entity> lines;
   u_int max_weight = 1000;
   u_int available_effort = 50;
+
+  Manufacturing(size_t num) : lines(num) {}
 };
 
 /// @brief For rockets and payloads


### PR DESCRIPTION
- Expands the Sprite component to support all types of texture clipping
- Adds TileMap component to simplify clipping from tilemap texture
- Adds scaling, rotation and flipping to Sprite
- Simplify texture loading by eliminating Surface step
- Move all loading operations into startup systems outside of RenderModule