### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/pkuehne/solcorp/security/code-scanning/4](https://github.com/pkuehne/solcorp/security/code-scanning/4)

Add a workflow-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit minimal token access.  
Best fix here: add

```yml
permissions:
  contents: read
```

near the top level (e.g., after `concurrency` and before `jobs`). This preserves existing behavior for checkout/build/test while explicitly restricting `GITHUB_TOKEN` and satisfying CodeQL. No imports/methods/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
