### PR TITLE
ci: fix release-please config missing packages definition

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "simple",
-  "bump-minor-pre-major": true
+  "packages": {
+    ".": {
+      "release-type": "simple",
+      "bump-minor-pre-major": true
+    }
+  }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,21 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "prerelease": true,
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance Improvements"},
+        {"type": "revert", "section": "Reverts"},
+        {"type": "refactor", "section": "Refactoring"},
+        {"type": "chore", "section": "Chores"},
+        {"type": "docs", "section": "Documentation", "hidden": true},
+        {"type": "style", "section": "Styles", "hidden": true},
+        {"type": "test", "section": "Tests", "hidden": true},
+        {"type": "build", "section": "Build System", "hidden": true},
+        {"type": "ci", "section": "CI", "hidden": true}
+      ]
     }
   }
 }


### PR DESCRIPTION
Top-level release-type is not picked up by release-please v4 without a packages entry; moving config under packages["."] so it correctly tracks the repo root and picks up conventional commits.