### PR TITLE
feat(lua): clean up core mod

### DIFF
--- a/mods/core/init.lua
+++ b/mods/core/init.lua
@@ -62,26 +62,21 @@ local function on_start()
 	-- Create a new site
 	local site = solcorp.helpers.create_site("Cape Canaveral", 10, 10, true)
 
+	-- Add some buildings to the site
 	solcorp.helpers.create_building("Manufacturing A", "Factory", 1, 1, site)
-	solcorp.helpers.create_building("Storage Hall 1", "Storage Hall", 0, 0, site)
-	solcorp.helpers.create_building("Main Launchpad", "Launch Complex", 1, 0, site)
-	solcorp.helpers.create_building("North Building", "Office Building", 2, 0, site)
-	local south_pad = solcorp.helpers.create_building("South Launchpad", "Launch Complex", 5, 5, site)
+	local storage = solcorp.helpers.create_building("Storage Hall 1", "Storage Hall", 1, 0, site)
+	local main_launchpad = solcorp.helpers.create_building("Main Launchpad", "Launch Complex", 8, 5, site)
+	solcorp.helpers.create_building("North Building", "Office Building", 0, 6, site)
 
-	local e = solcorp.entities.create("south_launchpad")
-	e:child_of(south_pad)
-	e:getText().text = "South Launchpad"
-	e:getVelocity().y = -20
-	e:getTransform().relativePosition.y = -15
-	e:getExpire().millis = 2000
-
-	local concrete = solcorp.helpers.create_effect("Better Concrete", site)
+	-- Add some modifiers to the launchpad
 	local mod = solcorp.components.Modifier:new()
 	mod.target_stat = "max-weight"
+
+	local concrete = solcorp.helpers.create_effect("Better Concrete", site)
 	mod.multiplicative = 1.2
 	solcorp.helpers.add_modifier(concrete, mod)
 
-	local cracks = solcorp.helpers.create_effect("Cracks detected", south_pad)
+	local cracks = solcorp.helpers.create_effect("Cracks detected", main_launchpad)
 	mod.multiplicative = 0.4
 	solcorp.helpers.add_modifier(cracks, mod)
 
@@ -90,17 +85,16 @@ local function on_start()
 	mod.additive = 500
 	solcorp.helpers.add_modifier(struts, mod)
 
-	mod.target_stat = "prep-days"
-	mod.multiplicative = 1.0
-	mod.additive = 3
-	solcorp.helpers.add_modifier(cracks, mod)
-
 	-- Create a rocket prefab
 	local rocket = solcorp.helpers.create_rocket_prefab("Falcon 1")
 	solcorp.helpers.add_target_orbit_to_rocket(rocket, "Sun::Earth::Low Orbit", 6300)
 	solcorp.helpers.add_target_orbit_to_rocket(rocket, "Sun::Earth::Polar Orbit", 5600)
 	solcorp.helpers.add_target_orbit_to_rocket(rocket, "Sun::Earth::Transfer Orbit", 3300)
 	solcorp.helpers.add_target_orbit_to_rocket(rocket, "Sun::Earth::Synchronous Orbit", 1300)
+
+	-- Create a rocket
+	local hall = storage:lookup("Hall 1")
+	solcorp.helpers.create_rocket("Falcon 1 - Unit 001", "Falcon 1", hall)
 end
 
 local function get_random_contract_name()

--- a/mods/core/init.lua
+++ b/mods/core/init.lua
@@ -13,6 +13,9 @@ local function on_init()
 	e:destroy()
 end
 
+local get_random_contract_name
+local get_random_company_name
+
 local function on_start()
 	local info = solcorp.logging.info
 	info("on_start called!")
@@ -95,9 +98,24 @@ local function on_start()
 	-- Create a rocket
 	local hall = storage:lookup("Hall 1")
 	solcorp.helpers.create_rocket("Falcon 1 - Unit 001", "Falcon 1", hall)
+
+	-- Create a contract
+	local contract = solcorp.helpers.create_contract(
+		get_random_contract_name(),
+		get_random_company_name(),
+		"Launch your first satellite into low Earth orbit.",
+		2 * 1000 * 1000,
+		2 * 1000 * 1000
+	)
+	solcorp.helpers.create_contract_payload(
+		contract,
+		"Satellite " .. math.random(100, 10000),
+		800,
+		"Sun::Earth::Low Orbit"
+	)
 end
 
-local function get_random_contract_name()
+get_random_contract_name = function()
 	local names = {
 		"Launch Satellite",
 		"Deploy Space Station Module",
@@ -113,7 +131,7 @@ local function get_random_contract_name()
 	return names[math.random(1, #names)]
 end
 
-local function get_random_company_name()
+get_random_company_name = function()
 	local names = {
 		"SpaceY",
 		"Galactic Ventures",

--- a/src/modules/engine/gui.cpp
+++ b/src/modules/engine/gui.cpp
@@ -17,7 +17,7 @@ void systemRenderGUI(const Renderer &);
 void systemRenderWindow(flecs::entity winE, Window &win);
 
 void registerGui(flecs::world &world) {
-  world.import <EngineModule>();
+  world.import<EngineModule>();
 
   // Register Systems
   world.system("Initialise GUI").kind(flecs::OnStart).run(systemInitialiseGui);
@@ -152,7 +152,7 @@ registerWindow(std::string name,
     windows = world.entity("Windows");
   }
   return world.entity(name.c_str())
-      .set<Window>({false, content_renderer})
+      .set<Window>({false, name, content_renderer})
       .child_of(windows);
 }
 
@@ -161,7 +161,9 @@ void systemRenderWindow(flecs::entity winE, Window &win) {
     return;
   }
 
-  ImGui::Begin(winE.name().c_str(), &win.open);
+  const char *title =
+      win.title.empty() ? winE.name().c_str() : win.title.c_str();
+  ImGui::Begin(title, &win.open);
   if (win.content_renderer) {
     win.content_renderer(winE);
   } else {

--- a/src/modules/engine/gui.cpp
+++ b/src/modules/engine/gui.cpp
@@ -17,7 +17,7 @@ void systemRenderGUI(const Renderer &);
 void systemRenderWindow(flecs::entity winE, Window &win);
 
 void registerGui(flecs::world &world) {
-  world.import<EngineModule>();
+  world.import <EngineModule>();
 
   // Register Systems
   world.system("Initialise GUI").kind(flecs::OnStart).run(systemInitialiseGui);

--- a/src/modules/engine/gui.h
+++ b/src/modules/engine/gui.h
@@ -6,6 +6,7 @@
 
 struct Window {
   bool open = false;
+  std::string title;
   std::function<void(flecs::entity)> content_renderer;
 };
 

--- a/src/modules/engine/render.cpp
+++ b/src/modules/engine/render.cpp
@@ -143,7 +143,7 @@ void initialiseGraphics(flecs::world &world) {
   }
   SDL_SetRenderDrawBlendMode(r.renderer, SDL_BLENDMODE_BLEND);
   SDL_GetRendererOutputSize(r.renderer, &m_width, &m_height);
-  SDL_SetRenderDrawColor(r.renderer, 0, 255, 0, SDL_ALPHA_OPAQUE);
+  SDL_SetRenderDrawColor(r.renderer, 42, 80, 35, SDL_ALPHA_OPAQUE);
   spdlog::info("Window ({}x{}) Tile ({}x{})", m_width, m_height, m_tileWidth,
                m_tileHeight);
 

--- a/src/modules/lua/entity.cpp
+++ b/src/modules/lua/entity.cpp
@@ -41,6 +41,9 @@ void load_entity_usertype(sol::state &mod_state) {
   flecs_entity["child_of"] = [](flecs::entity &e, flecs::entity &rhs) {
     e.child_of(rhs);
   };
+  flecs_entity["lookup"] = [](flecs::entity &e, const std::string &name) {
+    return e.lookup(name.c_str());
+  };
   flecs_entity["is_a"] = [](flecs::entity &e, const std::string &name) {
     auto world = e.world();
     std::string prefabPath = fmt::format("Prefabs::{}", name);

--- a/src/modules/lua/helpers.cpp
+++ b/src/modules/lua/helpers.cpp
@@ -32,7 +32,7 @@ flecs::entity create_site(sol::this_state s, const std::string &name,
 
   auto site = world->entity(name.c_str())
                   .set<Site>({width, height})
-                  .set<Transform>({{0, 50}, {}})
+                  .set<Transform>({{340, 240}, {}})
                   .add<ConstructionSiteNeedsUpdating>();
   if (make_current) {
     site.add<CurrentSite>();

--- a/src/modules/lua/helpers.cpp
+++ b/src/modules/lua/helpers.cpp
@@ -123,6 +123,41 @@ flecs::entity add_facility_to_building(sol::this_state s,
   return prefab;
 }
 
+/// @brief Creates a rocket entity instance from a prefab in the ECS world.
+///
+/// Instantiates a rocket from a prefab template. The prefab is looked up under
+/// the Prefabs::Rockets hierarchy. The instance is parented to the given entity
+/// if valid, otherwise falls back to a "Rockets" node (created on demand).
+///
+/// @param s The Lua state handle (injected by sol2).
+/// @param name The name identifier for the rocket instance.
+/// @param prefab The prefab template name to instantiate from.
+/// @param parent Optional parent entity. If invalid, defaults to "Rockets"
+/// node.
+/// @return A flecs::entity representing the newly created rocket, or an empty
+///         entity if the prefab does not exist.
+flecs::entity create_rocket(sol::this_state s, const std::string &name,
+                            const std::string &prefab,
+                            flecs::entity parent = flecs::entity::null()) {
+  sol::state_view mod_state(s);
+  auto world = mod_state["solcorp"]["world"].get<flecs::world *>();
+
+  std::string prefab_name = "Prefabs::Rockets::";
+  prefab_name.append(prefab);
+  auto prefab_entity = world->lookup(prefab_name.c_str());
+  if (!prefab_entity.is_valid()) {
+    spdlog::error("Rocket prefab {} does not exist", prefab_name);
+    return flecs::entity();
+  }
+
+  auto rocket = world->entity(name.c_str()).is_a(prefab_entity);
+  if (parent.is_valid()) {
+    rocket.child_of(parent);
+  }
+
+  return rocket;
+}
+
 /// @brief Creates a building entity in the ECS world through Lua bindings.
 ///
 /// Instantiates a building from a prefab template within the given site.
@@ -430,6 +465,7 @@ void load_helpers_namespace(sol::state &mod_state) {
   helpers.set_function("add_modifier", add_modifier);
   helpers.set_function("clip_sprite_from_texture", clip_sprite_from_texture);
   helpers.set_function("create_rocket_prefab", create_rocket_prefab);
+  helpers.set_function("create_rocket", create_rocket);
   helpers.set_function("add_target_orbit_to_rocket",
                        add_target_orbit_to_rocket);
   helpers.set_function("create_contract", create_contract);

--- a/src/modules/site/building_window.cpp
+++ b/src/modules/site/building_window.cpp
@@ -31,6 +31,9 @@ void showBuildingWindow(const flecs::entity &entity) {
   auto window = showWindow(world, "Building Window");
   SC_ASSERT(window.is_valid(),
             "showWindow returned invalid entity for Building Window");
+  auto win = window.try_get_mut<Window>();
+  SC_ASSERT(win, "Window state is invalid");
+  win->title = fmt::format("Building Window ({})", entity.name().c_str());
   auto state = window.try_get_mut<BuildingWindow>();
   SC_ASSERT(state, "BuildingWindow state is invalid");
   state->buildingE = entity;

--- a/src/modules/site/site.cpp
+++ b/src/modules/site/site.cpp
@@ -1,6 +1,7 @@
 #include "site.h"
 #include "building_window.h"
 #include "construction_window.h"
+#include "imgui.h"
 #include "modules/base/base.h"
 #include "modules/engine/engine.h"
 #include "modules/engine/gui.h"
@@ -109,6 +110,35 @@ SiteModule::SiteModule(flecs::world &world) {
       .each([](flecs::entity e, Launchpad &pad) {
         statsApplyModifiers(e, &pad.max_weight);
         statsApplyModifiers(e, &pad.prep_days);
+      });
+
+  world.system<const Site, const Transform>("Draw Site Border")
+      .with<CurrentSite>()
+      .kind(GuiPhase)
+      .each([](const Site &site, const Transform &t) {
+        const float x = t.worldPosition.x;
+        const float y = t.worldPosition.y;
+        const float w = site.width * 32.0f;
+        const float h = site.height * 32.0f;
+        const float ext = 7.0f;
+
+        const ImU32 glow   = IM_COL32(100, 180, 255,  45);
+        const ImU32 border = IM_COL32(120, 195, 255, 200);
+        const ImU32 cap    = IM_COL32(210, 235, 255, 255);
+
+        auto *dl = ImGui::GetBackgroundDrawList();
+        dl->AddRect({x - 3, y - 3}, {x + w + 3, y + h + 3}, glow,   0, 0, 5.0f);
+        dl->AddRect({x,     y    }, {x + w,     y + h    }, border, 0, 0, 2.0f);
+
+        // Corner accents — bright L-shaped caps at each corner
+        for (float cx : {x, x + w}) {
+          for (float cy : {y, y + h}) {
+            float sx = (cx == x) ? 1.0f : -1.0f;
+            float sy = (cy == y) ? 1.0f : -1.0f;
+            dl->AddLine({cx - sx * ext, cy}, {cx + sx * ext, cy}, cap, 2.0f);
+            dl->AddLine({cx, cy - sy * ext}, {cx, cy + sy * ext}, cap, 2.0f);
+          }
+        }
       });
 }
 

--- a/src/modules/site/site.cpp
+++ b/src/modules/site/site.cpp
@@ -122,13 +122,13 @@ SiteModule::SiteModule(flecs::world &world) {
         const float h = site.height * 32.0f;
         const float ext = 7.0f;
 
-        const ImU32 glow   = IM_COL32(100, 180, 255,  45);
+        const ImU32 glow = IM_COL32(100, 180, 255, 45);
         const ImU32 border = IM_COL32(120, 195, 255, 200);
-        const ImU32 cap    = IM_COL32(210, 235, 255, 255);
+        const ImU32 cap = IM_COL32(210, 235, 255, 255);
 
         auto *dl = ImGui::GetBackgroundDrawList();
-        dl->AddRect({x - 3, y - 3}, {x + w + 3, y + h + 3}, glow,   0, 0, 5.0f);
-        dl->AddRect({x,     y    }, {x + w,     y + h    }, border, 0, 0, 2.0f);
+        dl->AddRect({x - 3, y - 3}, {x + w + 3, y + h + 3}, glow, 0, 0, 5.0f);
+        dl->AddRect({x, y}, {x + w, y + h}, border, 0, 0, 2.0f);
 
         // Corner accents — bright L-shaped caps at each corner
         for (float cx : {x, x + w}) {


### PR DESCRIPTION
- Change background colour to a more earthy moss green (less garish)
- Centre the site in the initial window (does not resize see #99 
- Add a bounding box to the site (replace later with #100 )
- feat(site): Add name of building in the Building Window
- Added a couple of helpers to instantiate rockets from lua
- Added a rocket and a contract on startup
- Removed superfluous modifiers and the south launchpad
- Redistributed buildings for a more sprawling look

closes #76 