### PR TITLE
chore(ci): Replace nix cache image in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
           submodules: recursive
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v22
+        uses: nixbuild/nix-quick-install-action@v34
 
       - name: Set up Nix cache
-        uses: nix-community/cache-nix-action@v6
+        uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
@@ -56,10 +56,10 @@ jobs:
           submodules: recursive
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v22
+        uses: nixbuild/nix-quick-install-action@v34
 
       - name: Set up Nix cache
-        uses: nix-community/cache-nix-action@v6
+        uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v22
 
       - name: Set up Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
 
       - name: Cache CMake FetchContent
         uses: actions/cache@v5
@@ -56,7 +59,10 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v22
 
       - name: Set up Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
 
       - name: Cache CMake FetchContent
         uses: actions/cache@v5
@@ -142,7 +148,10 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v22
 
       - name: Set up Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
 
       - name: Check C++ formatting
         run: nix develop --command bash -c 'find src test -name "*.cpp" -o -name "*.h" -print0 | xargs -0 -r clang-format --dry-run -Werror'
@@ -161,7 +170,10 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v22
 
       - name: Set up Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
 
       - name: Lint Lua
         run: nix develop --command luacheck config.lua mods/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v22
+        uses: nixbuild/nix-quick-install-action@v34
 
       - name: Set up Nix cache
         uses: nix-community/cache-nix-action@v7
@@ -167,13 +167,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v22
+        uses: nixbuild/nix-quick-install-action@v34
 
       - name: Set up Nix cache
         uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
-
+            
       - name: Lint Lua
         run: nix develop --command luacheck config.lua mods/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,10 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v22
 
       - name: Set up Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
 
       - name: Cache CMake FetchContent
         uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: recursive
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v22
+        uses: nixbuild/nix-quick-install-action@v34
 
       - name: Set up Nix cache
         uses: nix-community/cache-nix-action@v7


### PR DESCRIPTION
Replaces the DeterminateSystems nix images in the Github Actions with community images. Closes #116 