### PR TITLE
ci(release): Ensure Release Please uses separate token to trigger releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,16 +4,12 @@ on:
   push:
     branches: ["main"]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to upload artifacts to (e.g. v0.1.0)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -46,6 +51,7 @@ jobs:
       - name: Upload to release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
           files: build-release/SolCorp-*.zip
 
   build-windows:
@@ -84,4 +90,5 @@ jobs:
       - name: Upload to release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
           files: build-release/SolCorp-*.zip

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,21 +4,60 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "extra-files": ["CMakeLists.txt"],
+      "extra-files": [
+        "CMakeLists.txt"
+      ],
       "bump-minor-pre-major": true,
-      "prerelease": true,
       "changelog-sections": [
-        {"type": "feat", "section": "Features"},
-        {"type": "fix", "section": "Bug Fixes"},
-        {"type": "perf", "section": "Performance Improvements"},
-        {"type": "revert", "section": "Reverts"},
-        {"type": "refactor", "section": "Refactoring"},
-        {"type": "chore", "section": "Chores"},
-        {"type": "docs", "section": "Documentation", "hidden": true},
-        {"type": "style", "section": "Styles", "hidden": true},
-        {"type": "test", "section": "Tests", "hidden": true},
-        {"type": "build", "section": "Build System", "hidden": true},
-        {"type": "ci", "section": "CI", "hidden": true}
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "refactor",
+          "section": "Refactoring"
+        },
+        {
+          "type": "chore",
+          "section": "Chores"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation",
+          "hidden": true
+        },
+        {
+          "type": "style",
+          "section": "Styles",
+          "hidden": true
+        },
+        {
+          "type": "test",
+          "section": "Tests",
+          "hidden": true
+        },
+        {
+          "type": "build",
+          "section": "Build System",
+          "hidden": true
+        },
+        {
+          "type": "ci",
+          "section": "CI",
+          "hidden": true
+        }
       ]
     }
   }


### PR DESCRIPTION
Release Please was using the standard GITHUB token, which meant it wouldn't trigger other workflows. This a) meant that some portions of CI weren't run and b) releases would be created but assets wouldn't be attached.

This also fixes the fact that release please was showing versions as "pre-release".

closes #115 