### PR TITLE
build(toolchain): Switch to clang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,40 @@ jobs:
       - name: Test
         run: nix develop --command ctest --test-dir build -C Release --output-on-failure
 
+  sanitize-linux:
+    name: "Sanitize (Linux)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v34
+
+      - name: Set up Nix cache
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+
+      - name: Cache CMake FetchContent
+        uses: actions/cache@v5
+        with:
+          path: build/_deps
+          key: fetchcontent-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: fetchcontent-
+
+      - name: Configure
+        run: nix develop --command cmake -B build -DCMAKE_BUILD_TYPE=Debug -DSC_RUN_SANITIZERS=ON -G Ninja
+
+      - name: Build
+        run: nix develop --command cmake --build build --target unit_test --parallel
+
+      - name: Test
+        run: nix develop --command ctest --test-dir build -C Debug --output-on-failure
+
   build-windows:
     name: "Build (Windows)"
     runs-on: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,13 @@ project(SolCorp
 message("Configuring ${PROJECT_NAME} v${PROJECT_VERSION}")
 option(SC_BUILD_TESTS "Whether to build the unit tests" ON)
 option(SC_LINT_COMPILATION "Whether to lint as we build with clang-tidy" OFF)
+option(SC_RUN_SANITIZERS "Whether to enable sanitizers" OFF)
 set(COVERAGE_PERCENTAGE 90 CACHE STRING "Minimum Coverage number to succeed")
+
+if(SC_RUN_SANITIZERS AND NOT MSVC)
+  add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer)
+  add_link_options(-fsanitize=address,undefined)
+endif()
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/flake.nix
+++ b/flake.nix
@@ -64,10 +64,10 @@
         tools = with pkgs; [
           cmake
           ninja
-          gcc
+          clang
+          clang-tools # clangd/clang-tidy
           gdb
           pkg-config
-          clang-tools # clangd/clang-tidy, handy even if you build with gcc
           git
           patchelf
           wl-clipboard
@@ -92,6 +92,9 @@
           # PKG_CONFIG_PATH = ...
 
           shellHook = ''
+            export CC=clang
+            export CXX=clang++
+
             # Prefer WSLg sockets
             if [ -S /mnt/wslg/runtime-dir/wayland-0 ]; then
               export XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir


### PR DESCRIPTION
Update the flake.nix to use clang as the compiler. Since we're using clang, its worth adding a CI job to run clang sanitizers as well to improve correctness checking on PR

closes #82 