### PR TITLE
ci(lint): Enable clang-tidy for linting

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,6 +24,6 @@ Checks: >-
   -modernize-avoid-c-arrays,
   -modernize-redundant-void-arg,
   -readability-identifier-length,
-WarningsAsErrors: ''
+WarningsAsErrors: '*'
 HeaderFilterRegex: '^.*/solcorp/(src|test)/.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,4 +26,4 @@ Checks: >-
   -readability-identifier-length,
 WarningsAsErrors: '*'
 HeaderFilterRegex: '^.*/solcorp/(src|test)/.*'
-FormatStyle: none
+FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,17 @@
+Checks: >-
+  bugprone-infinite-loop,
+  bugprone-use-after-move,
+  bugprone-macro-parentheses,
+  modernize-*,
+  -modernize-use-nullptr,
+  -modernize-return-braced-init-list,
+  -modernize-use-trailing-return-type,
+  -modernize-use-auto,
+  -modernize-use-nodiscard,
+  -modernize-pass-by-value,
+  -modernize-use-override,
+  -readability-identifier-length,
+  -bugprone-narrowing-conversions
+WarningsAsErrors: ''
+HeaderFilterRegex: '^.*/solcorp/(src|test)/.*'
+FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,19 @@
 Checks: >-
-  bugprone-infinite-loop,
-  bugprone-use-after-move,
-  bugprone-macro-parentheses,
+  clang-analyzer-*,
+  bugprone-*,
+  performance-*,
+  portability-*,
   modernize-*,
+  -clang-analyzer-deadcode.DeadStores,
+  -bugprone-narrowing-conversions,
+  -bugprone-macro-parentheses,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-branch-clone,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-multi-level-implicit-pointer-conversion,
+  -performance-move-const-arg,
+  -performance-enum-size,
+  -performance-unnecessary-value-param,
   -modernize-use-nullptr,
   -modernize-return-braced-init-list,
   -modernize-use-trailing-return-type,
@@ -10,8 +21,9 @@ Checks: >-
   -modernize-use-nodiscard,
   -modernize-pass-by-value,
   -modernize-use-override,
+  -modernize-avoid-c-arrays,
+  -modernize-redundant-void-arg,
   -readability-identifier-length,
-  -bugprone-narrowing-conversions
 WarningsAsErrors: ''
 HeaderFilterRegex: '^.*/solcorp/(src|test)/.*'
 FormatStyle: none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
         run: nix develop --command cmake -B build -DCMAKE_BUILD_TYPE=Debug -G Ninja
 
       - name: Lint C++
-        run: nix develop --command just lint-cpp
+        run: nix develop --command find src test -name "*.cpp" -print0 | xargs -0 -r -n 1 -P "$(nproc)" clang-tidy --quiet -p build
 
       - name: Lint Lua
-        run: nix develop --command just lint-lua
+        run: nix develop --command luacheck config.lua mods/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
         run: nix develop --command cmake --build build --parallel
 
       - name: Lint C++
-        run: nix develop --command find src test -name "*.cpp" -print0 | xargs -0 -r -n 1 -P "$(nproc)" clang-tidy --quiet -p build
+        run: nix develop --command bash -c 'find src test -name "*.cpp" -print0 | xargs -0 -r -n 1 -P "$(nproc)" clang-tidy --quiet -p build'
 
       - name: Lint Lua
         run: nix develop --command luacheck config.lua mods/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,8 +193,8 @@ jobs:
       - name: Check Lua formatting
         run: nix develop --command stylua --check config.lua mods/
 
-  lua-lint:
-    name: "Linter"
+  lint:
+    name: "Lint"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -208,6 +208,19 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
-            
+
+      - name: Cache CMake FetchContent
+        uses: actions/cache@v5
+        with:
+          path: build/_deps
+          key: fetchcontent-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: fetchcontent-
+
+      - name: Configure
+        run: nix develop --command cmake -B build -DCMAKE_BUILD_TYPE=Debug -G Ninja
+
+      - name: Lint C++
+        run: nix develop --command just lint-cpp
+
       - name: Lint Lua
-        run: nix develop --command luacheck config.lua mods/
+        run: nix develop --command just lint-lua

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,9 @@ jobs:
       - name: Configure
         run: nix develop --command cmake -B build -DCMAKE_BUILD_TYPE=Debug -G Ninja
 
+      - name: Build
+        run: nix develop --command cmake --build build --parallel
+
       - name: Lint C++
         run: nix develop --command find src test -name "*.cpp" -print0 | xargs -0 -r -n 1 -P "$(nproc)" clang-tidy --quiet -p build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v34

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,9 +221,6 @@ jobs:
       - name: Configure
         run: nix develop --command cmake -B build -DCMAKE_BUILD_TYPE=Debug -G Ninja
 
-      - name: Build
-        run: nix develop --command cmake --build build --parallel
-
       - name: Lint C++
         run: nix develop --command bash -c 'find src test -name "*.cpp" -print0 | xargs -0 -r -n 1 -P "$(nproc)" clang-tidy --quiet -p build'
 

--- a/Justfile
+++ b/Justfile
@@ -31,6 +31,7 @@ format-lua:
 lint: lint-cpp lint-lua 
 
 lint-cpp:
+    find src test -name "*.cpp" -print0 | xargs -0 -r -n 1 -P "$(nproc)" clang-tidy --quiet -p build
 
 lint-lua:
     luacheck config.lua mods/

--- a/flake.nix
+++ b/flake.nix
@@ -64,8 +64,8 @@
         tools = with pkgs; [
           cmake
           ninja
+          clang-tools # clangd/clang-tidy (must precede clang so wrapped binaries win PATH)
           clang
-          clang-tools # clangd/clang-tidy
           gdb
           pkg-config
           git


### PR DESCRIPTION
Adds clang-tidy as "just lint-cpp" and then hooks that into CI.

All current issues are explicitly disabled so the code passes as-is, while still stopping new issues (of different types) to be caught.

closes #83 