### PR TITLE
ci(toolchain): Use just commands for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: nix develop --command cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja -DSC_BUILD_TESTS=OFF
 
       - name: Build
-        run: nix develop --command cmake --build build --parallel
+        run: nix develop --command just build
 
   test-linux:
     name: "Test (Linux)"
@@ -72,13 +72,10 @@ jobs:
           restore-keys: fetchcontent-
 
       - name: Configure
-        run: nix develop --command cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja
-
-      - name: Build
-        run: nix develop --command cmake --build build --target unit_test --parallel
+        run: nix develop --command just init-debug
 
       - name: Test
-        run: nix develop --command ctest --test-dir build -C Release --output-on-failure
+        run: nix develop --command just test
 
   sanitize-linux:
     name: "Sanitize (Linux)"
@@ -106,13 +103,10 @@ jobs:
           restore-keys: fetchcontent-
 
       - name: Configure
-        run: nix develop --command cmake -B build -DCMAKE_BUILD_TYPE=Debug -DSC_RUN_SANITIZERS=ON -G Ninja
-
-      - name: Build
-        run: nix develop --command cmake --build build --target unit_test --parallel
+        run: nix develop --command just init-debug-sanitize
 
       - name: Test
-        run: nix develop --command ctest --test-dir build -C Debug --output-on-failure
+        run: nix develop --command just test
 
   build-windows:
     name: "Build (Windows)"
@@ -138,8 +132,7 @@ jobs:
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja -DSC_BUILD_TESTS=OFF -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
       - name: Build
-        run: |
-          cmake --build build --parallel
+        run: just build
 
   test-windows:
     name: "Test (Windows)"
@@ -164,12 +157,8 @@ jobs:
       - name: Configure
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
-      - name: Build
-        run: |
-          cmake --build build --target unit_test --parallel
       - name: Test
-        run: |
-          ctest --test-dir build -C Release --output-on-failure
+        run: just test
 
   format:
     name: "Formatting"
@@ -188,10 +177,10 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
 
       - name: Check C++ formatting
-        run: nix develop --command bash -c 'find src test -name "*.cpp" -o -name "*.h" -print0 | xargs -0 -r clang-format --dry-run -Werror'
+        run: nix develop --command just check-format-cpp
 
       - name: Check Lua formatting
-        run: nix develop --command stylua --check config.lua mods/
+        run: nix develop --command just check-format-lua
 
   lint:
     name: "Lint"
@@ -219,10 +208,10 @@ jobs:
           restore-keys: fetchcontent-
 
       - name: Configure
-        run: nix develop --command cmake -B build -DCMAKE_BUILD_TYPE=Debug -G Ninja
+        run: nix develop --command just init-debug
 
       - name: Lint C++
-        run: nix develop --command bash -c 'find src test -name "*.cpp" -print0 | xargs -0 -r -n 1 -P "$(nproc)" clang-tidy --quiet -p build'
+        run: nix develop --command just lint-cpp
 
       - name: Lint Lua
-        run: nix develop --command luacheck config.lua mods/
+        run: nix develop --command just lint-lua

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           restore-keys: fetchcontent-
 
       - name: Configure
-        run: nix develop --command cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja -DSC_BUILD_TESTS=OFF
+        run: nix develop --command cmake --preset release-no-tests
 
       - name: Build
         run: nix develop --command just build
@@ -72,7 +72,7 @@ jobs:
           restore-keys: fetchcontent-
 
       - name: Configure
-        run: nix develop --command just init-debug
+        run: nix develop --command just configure-debug
 
       - name: Test
         run: nix develop --command just test
@@ -103,7 +103,7 @@ jobs:
           restore-keys: fetchcontent-
 
       - name: Configure
-        run: nix develop --command just init-debug-sanitize
+        run: nix develop --command just configure-sanitize
 
       - name: Test
         run: nix develop --command just test
@@ -129,8 +129,7 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1
       - name: Configure
-        run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja -DSC_BUILD_TESTS=OFF -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+        run: cmake --preset windows-release-no-tests
       - name: Build
         run: just build
 
@@ -155,8 +154,7 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1
       - name: Configure
-        run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+        run: cmake --preset windows-release
       - name: Test
         run: just test
 
@@ -208,7 +206,7 @@ jobs:
           restore-keys: fetchcontent-
 
       - name: Configure
-        run: nix develop --command just init-debug
+        run: nix develop --command just configure-debug
 
       - name: Lint C++
         run: nix develop --command just lint-cpp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           restore-keys: fetchcontent-
 
       - name: Configure
-        run: nix develop --command cmake --preset release-no-tests
+        run: nix develop --command just configure-release-no-tests
 
       - name: Build
         run: nix develop --command just build
@@ -129,7 +129,7 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1
       - name: Configure
-        run: cmake --preset windows-release-no-tests
+        run: just configure-release-no-tests
       - name: Build
         run: just build
 
@@ -154,7 +154,7 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1
       - name: Configure
-        run: cmake --preset windows-release
+        run: just configure-debug
       - name: Test
         run: just test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+      - name: Install just
+        run: winget install --id Casey.Just --exact --accept-source-agreements --accept-package-agreements
       - name: Set up vcpkg
         uses: lukka/run-vcpkg@v11
         with:
@@ -141,6 +143,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+      - name: Install just
+        run: winget install --id Casey.Just --exact --accept-source-agreements --accept-package-agreements
       - name: Set up vcpkg
         uses: lukka/run-vcpkg@v11
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install just
-        run: winget install --id Casey.Just --exact --accept-source-agreements --accept-package-agreements
+        uses: extractions/setup-just@v4
       - name: Set up vcpkg
         uses: lukka/run-vcpkg@v11
         with:
@@ -144,7 +144,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install just
-        run: winget install --id Casey.Just --exact --accept-source-agreements --accept-package-agreements
+        uses: extractions/setup-just@v4
       - name: Set up vcpkg
         uses: lukka/run-vcpkg@v11
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: fetchcontent-linux-release-
 
       - name: Configure
-        run: nix develop --command cmake --preset release-no-tests
+        run: nix develop --command just configure-release-no-tests
 
       - name: Build
         run: nix develop --command just build
@@ -79,7 +79,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Configure
-        run: cmake --preset windows-release-no-tests
+        run: just configure-release-no-tests
 
       - name: Build
         run: just build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,24 +35,24 @@ jobs:
       - name: Cache CMake FetchContent
         uses: actions/cache@v5
         with:
-          path: build-release/_deps
+          path: build/_deps
           key: fetchcontent-linux-release-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: fetchcontent-linux-release-
 
       - name: Configure
-        run: nix develop --command cmake -B build-release -DCMAKE_BUILD_TYPE=Release -DSC_BUILD_TESTS=OFF -G Ninja
+        run: nix develop --command cmake --preset release-no-tests
 
       - name: Build
-        run: nix develop --command cmake --build build-release --parallel
+        run: nix develop --command just build
 
       - name: Package
-        run: nix develop --command cpack --config build-release/CPackConfig.cmake -B build-release
+        run: nix develop --command just package
 
       - name: Upload to release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
-          files: build-release/SolCorp-*.zip
+          files: build/SolCorp-*.zip
 
   build-windows:
     name: "Package Windows"
@@ -71,7 +71,7 @@ jobs:
       - name: Cache CMake FetchContent
         uses: actions/cache@v5
         with:
-          path: build-release/_deps
+          path: build/_deps
           key: fetchcontent-windows-release-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: fetchcontent-windows-release-
 
@@ -79,16 +79,16 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Configure
-        run: cmake -B build-release -DCMAKE_BUILD_TYPE=Release -G Ninja -DSC_BUILD_TESTS=OFF -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+        run: cmake --preset windows-release-no-tests
 
       - name: Build
-        run: cmake --build build-release --parallel
+        run: just build
 
       - name: Package
-        run: cpack --config build-release/CPackConfig.cmake -B build-release
+        run: just package
 
       - name: Upload to release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
-          files: build-release/SolCorp-*.zip
+          files: build/SolCorp-*.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ The project uses CMake with Ninja and provides a Justfile for convenience:
 
 ```bash
 # Initial setup (first time only)
-cmake -B build -G Ninja
+just configure
 
 # Build
 just build

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,41 +8,56 @@
       "binaryDir": "${sourceDir}/build"
     },
     {
-      "name": "debug",
-      "displayName": "Debug",
+      "name": "base-debug",
+      "hidden": true,
       "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
-      "name": "release",
-      "displayName": "Release",
+      "name": "base-release",
+      "hidden": true,
       "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
-      "name": "release-no-tests",
-      "displayName": "Release (no tests)",
-      "inherits": "release",
+      "name": "base-release-no-tests",
+      "hidden": true,
+      "inherits": "base-release",
       "cacheVariables": {
         "SC_BUILD_TESTS": "OFF"
       }
     },
     {
-      "name": "sanitize",
-      "displayName": "Debug with sanitizers",
-      "inherits": "debug",
+      "name": "linux-debug",
+      "displayName": "Linux Debug",
+      "inherits": "base-debug"
+    },
+    {
+      "name": "linux-release",
+      "displayName": "Linux Release",
+      "inherits": "base-release"
+    },
+    {
+      "name": "linux-release-no-tests",
+      "displayName": "Linux Release (no tests)",
+      "inherits": "base-release-no-tests"
+    },
+    {
+      "name": "linux-sanitize",
+      "displayName": "Linux Debug with sanitizers",
+      "inherits": "base-debug",
       "cacheVariables": {
         "SC_RUN_SANITIZERS": "ON"
       }
     },
     {
-      "name": "windows-release-no-tests",
-      "displayName": "Windows Release (no tests)",
-      "inherits": "release-no-tests",
+      "name": "windows-debug",
+      "displayName": "Windows Debug",
+      "inherits": "base-debug",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
       }
@@ -50,7 +65,15 @@
     {
       "name": "windows-release",
       "displayName": "Windows Release",
-      "inherits": "release",
+      "inherits": "base-release",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    },
+    {
+      "name": "windows-release-no-tests",
+      "displayName": "Windows Release (no tests)",
+      "inherits": "base-release-no-tests",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
       }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,59 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build"
+    },
+    {
+      "name": "debug",
+      "displayName": "Debug",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Release",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "release-no-tests",
+      "displayName": "Release (no tests)",
+      "inherits": "release",
+      "cacheVariables": {
+        "SC_BUILD_TESTS": "OFF"
+      }
+    },
+    {
+      "name": "sanitize",
+      "displayName": "Debug with sanitizers",
+      "inherits": "debug",
+      "cacheVariables": {
+        "SC_RUN_SANITIZERS": "ON"
+      }
+    },
+    {
+      "name": "windows-release-no-tests",
+      "displayName": "Windows Release (no tests)",
+      "inherits": "release-no-tests",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    },
+    {
+      "name": "windows-release",
+      "displayName": "Windows Release",
+      "inherits": "release",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    }
+  ]
+}

--- a/Justfile
+++ b/Justfile
@@ -15,9 +15,12 @@ configure-sanitize:
     cmake --preset sanitize
 
 install:
-    cmake --preset release-no-tests -B build-release
-    cmake --build build-release --parallel
-    cmake --install build-release --prefix dist
+    cmake --preset release-no-tests
+    cmake --build build --parallel
+    cmake --install build --prefix dist
+
+package:
+    cpack --config build/CPackConfig.cmake -B build
 
 build:
     cmake --build build --target all --parallel

--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,14 @@ help:
 init:
     cmake -B build -DCMAKE_BUILD_TYPE=Debug -G Ninja
 
+init-debug: init
+
+init-release:
+    cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja
+
+init-sanitize:
+    cmake -B build -DCMAKE_BUILD_TYPE=Debug -DSC_RUN_SANITIZERS=ON -G Ninja
+
 install:
     cmake -B build-release -DCMAKE_BUILD_TYPE=Release -DSC_BUILD_TESTS=OFF -G Ninja
     cmake --build build-release --parallel
@@ -27,6 +35,14 @@ format-cpp:
 
 format-lua:
     stylua config.lua mods/
+
+check-format: check-format-cpp check-format-lua
+
+check-format-cpp:
+    find src test \( -name "*.cpp" -o -name "*.h" \) -print0 | xargs -0 -r clang-format --dry-run -Werror
+
+check-format-lua:
+    stylua --check config.lua mods/
 
 lint: lint-cpp lint-lua 
 

--- a/Justfile
+++ b/Justfile
@@ -6,18 +6,21 @@ help:
     @just --list
 
 configure:
-    cmake --preset debug
+    cmake --preset {{ if os() == "windows" { "windows-debug" } else { "linux-debug" } }}
 
 configure-debug: configure
 
 configure-release:
-    cmake --preset release
+    cmake --preset {{ if os() == "windows" { "windows-release" } else { "linux-release" } }}
+
+configure-release-no-tests:
+    cmake --preset {{ if os() == "windows" { "windows-release-no-tests" } else { "linux-release-no-tests" } }}
 
 configure-sanitize:
-    cmake --preset sanitize
+    cmake --preset linux-sanitize
 
 install:
-    cmake --preset release-no-tests
+    just configure-release-no-tests
     cmake --build {{build_dir}} --parallel
     cmake --install {{build_dir}} --prefix dist
 

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,7 @@
 set windows-shell := ["powershell.exe", "-NoProfile", "-Command"]
 
+build_dir := "build"
+
 help:
     @just --list
 
@@ -16,20 +18,20 @@ configure-sanitize:
 
 install:
     cmake --preset release-no-tests
-    cmake --build build --parallel
-    cmake --install build --prefix dist
+    cmake --build {{build_dir}} --parallel
+    cmake --install {{build_dir}} --prefix dist
 
 package:
-    cpack --config build/CPackConfig.cmake -B build
+    cpack --config {{build_dir}}/CPackConfig.cmake -B {{build_dir}}
 
 build:
-    cmake --build build --target all --parallel
+    cmake --build {{build_dir}} --target all --parallel
 
 test:
-    cmake --build build --target unit_tests --parallel
+    cmake --build {{build_dir}} --target unit_tests --parallel
 
 run:
-    cmake --build build --target run --parallel
+    cmake --build {{build_dir}} --target run --parallel
 
 format: format-cpp format-lua
 
@@ -50,7 +52,7 @@ check-format-lua:
 lint: lint-cpp lint-lua 
 
 lint-cpp:
-    find src test -name "*.cpp" -print0 | xargs -0 -r -n 1 -P "$(nproc)" clang-tidy --quiet -p build
+    find src test -name "*.cpp" -print0 | xargs -0 -r -n 1 -P "$(nproc)" clang-tidy --quiet -p {{build_dir}}
 
 lint-lua:
     luacheck config.lua mods/

--- a/Justfile
+++ b/Justfile
@@ -3,19 +3,19 @@ set windows-shell := ["powershell.exe", "-NoProfile", "-Command"]
 help:
     @just --list
 
-init:
-    cmake -B build -DCMAKE_BUILD_TYPE=Debug -G Ninja
+configure:
+    cmake --preset debug
 
-init-debug: init
+configure-debug: configure
 
-init-release:
-    cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja
+configure-release:
+    cmake --preset release
 
-init-sanitize:
-    cmake -B build -DCMAKE_BUILD_TYPE=Debug -DSC_RUN_SANITIZERS=ON -G Ninja
+configure-sanitize:
+    cmake --preset sanitize
 
 install:
-    cmake -B build-release -DCMAKE_BUILD_TYPE=Release -DSC_BUILD_TESTS=OFF -G Ninja
+    cmake --preset release-no-tests -B build-release
     cmake --build build-release --parallel
     cmake --install build-release --prefix dist
 

--- a/Justfile
+++ b/Justfile
@@ -2,63 +2,84 @@ set windows-shell := ["powershell.exe", "-NoProfile", "-Command"]
 
 build_dir := "build"
 
+# List available commands
 help:
     @just --list
 
+# Configure for debug (default)
 configure:
     cmake --preset {{ if os() == "windows" { "windows-debug" } else { "linux-debug" } }}
 
+# Configure for debug
 configure-debug: configure
 
+# Configure for release
 configure-release:
     cmake --preset {{ if os() == "windows" { "windows-release" } else { "linux-release" } }}
 
+# Configure for release and don't build tests
 configure-release-no-tests:
     cmake --preset {{ if os() == "windows" { "windows-release-no-tests" } else { "linux-release-no-tests" } }}
 
+# Configure for debug with sanitizers
 configure-sanitize:
     cmake --preset linux-sanitize
 
+# Configure, build, and install a release build to dist/
 install:
     just configure-release-no-tests
     cmake --build {{build_dir}} --parallel
     cmake --install {{build_dir}} --prefix dist
 
+# Package the build with CPack
 package:
     cpack --config {{build_dir}}/CPackConfig.cmake -B {{build_dir}}
 
+# Build the entire project
 build:
     cmake --build {{build_dir}} --target all --parallel
 
+# Build and run tests
 test:
     cmake --build {{build_dir}} --target unit_tests --parallel
 
+# Build and run the game
 run:
     cmake --build {{build_dir}} --target run --parallel
 
+# Format all C++ and Lua source files
 format: format-cpp format-lua
 
+# Format C++ source files
 format-cpp:
     find src test \( -name "*.cpp" -o -name "*.h" \) -print0 | xargs -0 -r clang-format -i
 
+# Format Lua source files
 format-lua:
     stylua config.lua mods/
 
+# Check formatting for all C++ and Lua source files
 check-format: check-format-cpp check-format-lua
 
+# Check C++ formatting without modifying files
 check-format-cpp:
     find src test \( -name "*.cpp" -o -name "*.h" \) -print0 | xargs -0 -r clang-format --dry-run -Werror
 
+# Check Lua formatting without modifying files
 check-format-lua:
     stylua --check config.lua mods/
 
-lint: lint-cpp lint-lua 
+# Lint all C++ and Lua source files
+lint: lint-cpp lint-lua
 
+# Lint C++ source files with clang-tidy
 lint-cpp:
     find src test -name "*.cpp" -print0 | xargs -0 -r -n 1 -P "$(nproc)" clang-tidy --quiet -p {{build_dir}}
 
+# Lint Lua source files with luacheck
 lint-lua:
     luacheck config.lua mods/
 
+# Serve documentation locally
 docs:
     python3 -m http.server 8000 --directory docs

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
         tools = with pkgs; [
           cmake
           ninja
+          just
           clang-tools # clangd/clang-tidy (must precede clang so wrapped binaries win PATH)
           clang
           gdb


### PR DESCRIPTION
This aligns dev workflow and CI workflow. Also tidies up the justfile a bit and switches to use cmake presets.

closes #131 