### PR TITLE
feat(rocket): Rockets can now be set to automatically move to storage after being built

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,8 +26,8 @@ int main() {
   world.import <StatsModule>();
   world.import <SimulationModule>();
   world.import <WindowModule>();
-  world.import <SiteModule>();
   world.import <RocketModule>();
+  world.import <SiteModule>();
   world.import <StaffModule>();
 
   // Main Loop

--- a/src/modules/rocket/actions.cpp
+++ b/src/modules/rocket/actions.cpp
@@ -30,6 +30,8 @@ ScheduleLaunchAction::validate(const flecs::world &world) const {
   }
   auto launchPrepDays =
       static_cast<uint32_t>(launchpad.get<Launchpad>().prep_days.value());
+  // TODO(#95): Remove this when refactoring, rockets shouldn't know about
+  // launchpads
   bool clash = false;
   launchpad.each<LaunchingFrom>([&](flecs::entity p) {
     auto launch = p.get<LaunchPlan>();
@@ -254,6 +256,7 @@ void RocketCompleteBuildAction::execute(flecs::world &world) {
   rocket.get_mut<Rocket>().state = RocketStateId::Stored;
   rocket.remove<EffortRequired>();
   rocket.remove<RocketTargetState>();
+  rocket.remove<RocketStateTransitionBlocked>();
 }
 
 void RocketCompleteBuildAction::block(flecs::world &world) {
@@ -274,8 +277,11 @@ ValidationResult RocketMoveAction::validate(const flecs::world &) const {
     return ValidationResult::Fail("Rocket is not valid");
   }
   if (rocket.has<Rocket>() &&
-      rocket.get<Rocket>().state == RocketStateId::UnderConstruction) {
-    return ValidationResult::Fail("Rocket is under construction");
+      rocket.get<Rocket>().state != RocketStateId::Stored) {
+    return ValidationResult::Fail("Rocket is not stored already");
+  }
+  if (rocket.has<EffortRequired>()) {
+    return ValidationResult::Fail("Rocket has unfinished effort");
   }
   if (!destination.is_valid()) {
     return ValidationResult::Fail("Destination is not valid");
@@ -292,8 +298,8 @@ void RocketMoveAction::execute(flecs::world &world) {
     return;
   }
   rocket.add<RocketTargetParent>(destination);
-  rocket.ensure<RocketTargetState>().target = RocketStateId::Stored;
   rocket.get_mut<Rocket>().state = RocketStateId::Moving;
+  rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
   rocket.set<DurationRequired>({.remaining = days, .total = days});
 }
 
@@ -328,6 +334,7 @@ void RocketCompleteMoveAction::execute(flecs::world &world) {
   rocket.remove<RocketTargetState>();
   rocket.remove<RocketTargetParent>();
   rocket.remove<DurationRequired>();
+  rocket.remove<RocketStateTransitionBlocked>();
 }
 
 void RocketCompleteMoveAction::block(flecs::world &world) {

--- a/src/modules/rocket/actions.cpp
+++ b/src/modules/rocket/actions.cpp
@@ -276,9 +276,12 @@ ValidationResult RocketMoveAction::validate(const flecs::world &) const {
   if (!rocket.is_valid()) {
     return ValidationResult::Fail("Rocket is not valid");
   }
-  if (rocket.has<Rocket>() &&
-      rocket.get<Rocket>().state != RocketStateId::Stored) {
-    return ValidationResult::Fail("Rocket is not stored already");
+  if (!rocket.has<Rocket>()) {
+    return ValidationResult::Fail("This is not a rocket");
+  }
+  if (rocket.get<Rocket>().state != RocketStateId::Stored) {
+    return ValidationResult::Fail(
+        "Rocket must be currently stored to be moved");
   }
   if (rocket.has<EffortRequired>()) {
     return ValidationResult::Fail("Rocket has unfinished effort");

--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -37,6 +37,7 @@ RocketModule::RocketModule(flecs::world &world) {
       .member("rocket", &ScheduleLaunchAction::rocket)
       .member("launchpad", &ScheduleLaunchAction::launchpad);
   world.component<RocketStateId>()
+      .constant("Invalid", RocketStateId::Invalid)
       .constant("UnderConstruction", RocketStateId::UnderConstruction)
       .constant("Stored", RocketStateId::Stored)
       .constant("Moving", RocketStateId::Moving)
@@ -101,6 +102,7 @@ RocketModule::RocketModule(flecs::world &world) {
       });
   register_enum_table_lua(world, "RocketStateId", [](LuaEnumBuilder &b) {
     b.value("UnderConstruction", RocketStateId::UnderConstruction)
+        .value("Invalid", RocketStateId::Invalid)
         .value("Stored", RocketStateId::Stored)
         .value("Moving", RocketStateId::Moving)
         .value("Assigned", RocketStateId::Assigned)

--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -173,8 +173,10 @@ RocketModule::RocketModule(flecs::world &world) {
         registerWindow("Contracts Window", drawContractsWindow, world)
             .set<ContractsWindow>({});
       });
-  world.system<>("Rocket Complete State Transition Action")
+  world.system<Rocket>("Rocket Complete State Transition Action")
+      .immediate()
       .tick_source(sim.speed)
+      .with<RocketTargetState>()
       .with<DurationRequired>()
       .oper(flecs::Or)
       .with<EffortRequired>()
@@ -280,11 +282,11 @@ void systemCreateRocketPrefabs(flecs::iter &it) {
   world.prefab("Rocket").child_of(core_node).add<Rocket>();
 }
 
-void systemRocketCompleteAction(flecs::entity e) {
+void systemRocketCompleteAction(flecs::entity e, Rocket &rocket) {
   auto world = e.world();
   std::unique_ptr<IAction> action;
 
-  switch (e.get<Rocket>().state) {
+  switch (rocket.state) {
   case RocketStateId::UnderConstruction:
     action = std::make_unique<RocketCompleteBuildAction>(e);
     break;
@@ -297,7 +299,7 @@ void systemRocketCompleteAction(flecs::entity e) {
 
   if (!action) {
     spdlog::error("No completion action found for rocket {} in state: {}",
-                  e.name().c_str(), static_cast<int>(e.get<Rocket>().state));
+                  e.name().c_str(), static_cast<int>(rocket.state));
     return;
   }
   if (action->validate(world)) {

--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -23,7 +23,6 @@ uint32_t Rocket::max_id = 1;
 /// @brief Module Constructor
 /// Sets up all necessary components, GUIs and Systems
 RocketModule::RocketModule(flecs::world &world) {
-  spdlog::debug("Loading RocketModule");
 
   world.import <BaseModule>();
   world.import <StatsModule>();

--- a/src/modules/rocket/rocket_module.h
+++ b/src/modules/rocket/rocket_module.h
@@ -17,6 +17,7 @@ struct LaunchPlan {
 };
 
 enum class RocketStateId : uint8_t {
+  Invalid = 0,
   UnderConstruction,
   Stored,
   Moving,
@@ -95,7 +96,7 @@ struct ContractTargetOrbit {}; ///< Which orbit is targeted by a contract
 // Systems
 void systemLaunchRocket(flecs::entity, LaunchPlan &);
 void systemCreateRocketPrefabs(flecs::iter &);
-void systemRocketCompleteAction(flecs::entity);
+void systemRocketCompleteAction(flecs::entity, Rocket &);
 
 struct RocketModule {
   RocketModule(flecs::world &);

--- a/src/modules/simulation/developer_window.cpp
+++ b/src/modules/simulation/developer_window.cpp
@@ -1,8 +1,11 @@
 #include "developer_window.h"
 #include "imgui.h"
 #include "modules/engine/gui.h"
+#include "modules/simulation/simulation.h"
 #include <flecs.h>
 #include <spdlog/spdlog.h>
+
+void drawCheatsTab(flecs::world &);
 
 void showDeveloperWindow(flecs::world &world) {
   showWindow(world, "Developer Window");
@@ -23,12 +26,24 @@ void drawDeveloperWindow(flecs::entity winE) {
   ImGui::Checkbox("Show Metrics Window", &state.show_metrics_window);
 
   if (ImGui::BeginTabBar("Tools")) {
-    if (ImGui::BeginTabItem("Entity Tree")) {
+    if (ImGui::BeginTabItem("Cheats")) {
+      drawCheatsTab(world);
+      ImGui::EndTabItem();
     }
-    world.children([](flecs::entity e) { child_tree(e); });
+    if (ImGui::BeginTabItem("Entity Tree")) {
+      world.children([](flecs::entity e) { child_tree(e); });
+      ImGui::EndTabItem();
+    }
+    ImGui::EndTabBar();
   }
 
   if (state.show_metrics_window) {
     ImGui::ShowMetricsWindow();
+  }
+}
+
+void drawCheatsTab(flecs::world &world) {
+  if (ImGui::Button("Add $10M to balance")) {
+    world.get_mut<Company>().balance += 10'000'000;
   }
 }

--- a/src/modules/site/rocket_prefab_window.cpp
+++ b/src/modules/site/rocket_prefab_window.cpp
@@ -5,6 +5,7 @@
 #include "modules/rocket/actions.h"
 #include "modules/rocket/rocket_module.h"
 #include "modules/simulation/simulation.h"
+#include "modules/site/site.h"
 #include "modules/stats/stats.h"
 #include "spdlog/fmt/bundled/core.h"
 #include "widgets/widgets.h"
@@ -119,6 +120,7 @@ void drawRocketPrefabWindow(flecs::entity winE) {
                 std::format("Build '{}'", prefabE.name().c_str()).c_str()},
             ButtonTooltip{"Build this rocket"}, result.message)) {
       action.execute(world);
+      manufacturingE.add<ManufacturingLineTemplate>(prefabE);
       hideWindow(world, "Rocket Prefab Window");
     }
 

--- a/src/modules/site/site.cpp
+++ b/src/modules/site/site.cpp
@@ -118,10 +118,6 @@ SiteModule::SiteModule(flecs::world &world) {
       .term_at(1)
       .src()
       .up(flecs::ChildOf)
-      .with<ManufacturingLineStorage>(flecs::Wildcard)
-      .src()
-      .up(flecs::ChildOf)
-      .without<EffortRequired>()
       .tick_source(sim.speed)
       .kind(UpdatePhase)
       .each(systemAutoStoreBuiltRocket);
@@ -327,9 +323,7 @@ void systemAutoStoreBuiltRocket(flecs::entity rocketE, Rocket &rocket,
 
   flecs::entity lineE = rocketE.parent();
   flecs::entity storageE = lineE.target<ManufacturingLineStorage>();
-  if (!storageE.is_valid()) {
-    return;
-  }
+  // Validity will be checked in the action validation.
 
   auto world = rocketE.world();
   RocketMoveAction action{RocketEntity{rocketE}, DestinationEntity{storageE},

--- a/src/modules/site/site.cpp
+++ b/src/modules/site/site.cpp
@@ -11,6 +11,7 @@
 #include "modules/site/helpers.h"
 #include "modules/stats/stats.h"
 #include "modules/window/building_detail_window.h"
+#include "modules/rocket/actions.h"
 #include "rocket_prefab_window.h"
 #include "site_construction.h"
 #include <spdlog/spdlog.h>
@@ -45,6 +46,8 @@ SiteModule::SiteModule(flecs::world &world) {
   world.component<Manufacturing>()
       .member("max_weight", &Manufacturing::max_weight)
       .member("available_effort", &Manufacturing::available_effort);
+  world.component<ManufacturingLineTemplate>();
+  world.component<ManufacturingLineStorage>();
   world.component<Storage>().member("max_storage", &Storage::max_storage);
   world.component<Office>().member("max_desks", &Office::max_desks);
   world.component<Launchpad>()
@@ -99,6 +102,12 @@ SiteModule::SiteModule(flecs::world &world) {
       .tick_source(sim.speed)
       .kind(UpdatePhase)
       .each(systemBuildingUpdateManufacuringProgress);
+
+  world.system<const Manufacturing>("Auto Start Next Build")
+      .with<ManufacturingLineTemplate>(flecs::Wildcard)
+      .tick_source(sim.speed)
+      .kind(UpdatePhase)
+      .each(systemAutoStartNextBuild);
 
   world.system<Transform, Sprite, const MouseUp>("Match click to Building")
       .with<SiteLocation>()
@@ -250,5 +259,34 @@ void systemBuildingUpdateManufacuringProgress(
     effort.remaining = 0;
   } else {
     effort.remaining -= manufacturing.available_effort;
+  }
+}
+
+void systemAutoStartNextBuild(flecs::entity manufacturingE,
+                              const Manufacturing &manufacturing) {
+  if (!manufacturing.auto_build_next) {
+    return;
+  }
+
+  bool line_busy = false;
+  manufacturingE.children([&](flecs::entity child) {
+    if (child.has<Rocket>()) {
+      line_busy = true;
+    }
+  });
+  if (line_busy) {
+    return;
+  }
+
+  flecs::entity prefabE = manufacturingE.target<ManufacturingLineTemplate>();
+  if (!prefabE.is_valid()) {
+    return;
+  }
+
+  auto world = manufacturingE.world();
+  int64_t cost = computeRocketPrefabBuildCost(prefabE);
+  RocketBuildAction action{PrefabEntity{prefabE}, LineEntity{manufacturingE}, cost};
+  if (action.validate(world)) {
+    action.execute(world);
   }
 }

--- a/src/modules/site/site.cpp
+++ b/src/modules/site/site.cpp
@@ -7,11 +7,11 @@
 #include "modules/engine/input.h"
 #include "modules/engine/render.h"
 #include "modules/lua/lua.h"
+#include "modules/rocket/actions.h"
 #include "modules/rocket/rocket_module.h"
 #include "modules/site/helpers.h"
 #include "modules/stats/stats.h"
 #include "modules/window/building_detail_window.h"
-#include "modules/rocket/actions.h"
 #include "rocket_prefab_window.h"
 #include "site_construction.h"
 #include <spdlog/spdlog.h>
@@ -48,6 +48,7 @@ SiteModule::SiteModule(flecs::world &world) {
       .member("available_effort", &Manufacturing::available_effort);
   world.component<ManufacturingLineTemplate>();
   world.component<ManufacturingLineStorage>();
+  world.component<AutoBuildBlocked>();
   world.component<Storage>().member("max_storage", &Storage::max_storage);
   world.component<Office>().member("max_desks", &Office::max_desks);
   world.component<Launchpad>()
@@ -285,8 +286,14 @@ void systemAutoStartNextBuild(flecs::entity manufacturingE,
 
   auto world = manufacturingE.world();
   int64_t cost = computeRocketPrefabBuildCost(prefabE);
-  RocketBuildAction action{PrefabEntity{prefabE}, LineEntity{manufacturingE}, cost};
-  if (action.validate(world)) {
+  RocketBuildAction action{PrefabEntity{prefabE}, LineEntity{manufacturingE},
+                           cost};
+  auto result = action.validate(world);
+  if (result.ok) {
+    manufacturingE.remove<AutoBuildBlocked>();
     action.execute(world);
+  } else if (!manufacturingE.has<AutoBuildBlocked>()) {
+    manufacturingE.add<AutoBuildBlocked>();
+    instantiateBuildingNotification(world, manufacturingE, result.message);
   }
 }

--- a/src/modules/site/site.cpp
+++ b/src/modules/site/site.cpp
@@ -45,7 +45,9 @@ SiteModule::SiteModule(flecs::world &world) {
   world.component<Facility>();
   world.component<Manufacturing>()
       .member("max_weight", &Manufacturing::max_weight)
-      .member("available_effort", &Manufacturing::available_effort);
+      .member("available_effort", &Manufacturing::available_effort)
+      .member("auto_build_next", &Manufacturing::auto_build_next)
+      .member("auto_store", &Manufacturing::auto_store);
   world.component<ManufacturingLineTemplate>();
   world.component<ManufacturingLineStorage>();
   world.component<AutoBuildBlocked>();
@@ -81,7 +83,9 @@ SiteModule::SiteModule(flecs::world &world) {
   register_component_lua<Manufacturing>(
       world, "Manufacturing", [](LuaFieldBuilder<Manufacturing> &b) {
         b.field<&Manufacturing::max_weight>("max_weight")
-            .field<&Manufacturing::available_effort>("available_effort");
+            .field<&Manufacturing::available_effort>("available_effort")
+            .field<&Manufacturing::auto_build_next>("auto_build_next")
+            .field<&Manufacturing::auto_store>("auto_store");
       });
 
   // Register Systems
@@ -109,6 +113,11 @@ SiteModule::SiteModule(flecs::world &world) {
       .tick_source(sim.speed)
       .kind(UpdatePhase)
       .each(systemAutoStartNextBuild);
+  world.system<const Manufacturing>("Auto Store Built Rocket")
+      .with<ManufacturingLineStorage>(flecs::Wildcard)
+      .tick_source(sim.speed)
+      .kind(UpdatePhase)
+      .each(systemAutoStoreBuiltRocket);
 
   world.system<Transform, Sprite, const MouseUp>("Match click to Building")
       .with<SiteLocation>()
@@ -294,6 +303,40 @@ void systemAutoStartNextBuild(flecs::entity manufacturingE,
     action.execute(world);
   } else if (!manufacturingE.has<AutoBuildBlocked>()) {
     manufacturingE.add<AutoBuildBlocked>();
+    instantiateBuildingNotification(world, manufacturingE, result.message);
+  }
+}
+
+void systemAutoStoreBuiltRocket(flecs::entity manufacturingE,
+                                const Manufacturing &manufacturing) {
+  if (!manufacturing.auto_store) {
+    return;
+  }
+
+  flecs::entity rocket;
+  manufacturingE.children([&](flecs::entity child) {
+    if (child.has<Rocket>() &&
+        child.get<Rocket>().state == RocketStateId::Stored) {
+      rocket = child;
+    }
+  });
+  if (!rocket.is_alive()) {
+    return;
+  }
+
+  flecs::entity storageE = manufacturingE.target<ManufacturingLineStorage>();
+  if (!storageE.is_valid()) {
+    return;
+  }
+
+  auto world = manufacturingE.world();
+  RocketMoveAction action{RocketEntity{rocket}, DestinationEntity{storageE}, 1};
+  auto result = action.validate(world);
+  if (result.ok) {
+    manufacturingE.remove<AutoStoreBlocked>();
+    action.execute(world);
+  } else if (!manufacturingE.has<AutoStoreBlocked>()) {
+    manufacturingE.add<AutoStoreBlocked>();
     instantiateBuildingNotification(world, manufacturingE, result.message);
   }
 }

--- a/src/modules/site/site.cpp
+++ b/src/modules/site/site.cpp
@@ -51,6 +51,7 @@ SiteModule::SiteModule(flecs::world &world) {
   world.component<ManufacturingLineTemplate>();
   world.component<ManufacturingLineStorage>();
   world.component<AutoBuildBlocked>();
+  world.component<AutoStoreBlocked>();
   world.component<Storage>().member("max_storage", &Storage::max_storage);
   world.component<Office>().member("max_desks", &Office::max_desks);
   world.component<Launchpad>()
@@ -113,8 +114,14 @@ SiteModule::SiteModule(flecs::world &world) {
       .tick_source(sim.speed)
       .kind(UpdatePhase)
       .each(systemAutoStartNextBuild);
-  world.system<const Manufacturing>("Auto Store Built Rocket")
+  world.system<Rocket, const Manufacturing>("Auto Store Built Rocket")
+      .term_at(1)
+      .src()
+      .up(flecs::ChildOf)
       .with<ManufacturingLineStorage>(flecs::Wildcard)
+      .src()
+      .up(flecs::ChildOf)
+      .without<EffortRequired>()
       .tick_source(sim.speed)
       .kind(UpdatePhase)
       .each(systemAutoStoreBuiltRocket);
@@ -304,39 +311,37 @@ void systemAutoStartNextBuild(flecs::entity manufacturingE,
   } else if (!manufacturingE.has<AutoBuildBlocked>()) {
     manufacturingE.add<AutoBuildBlocked>();
     instantiateBuildingNotification(world, manufacturingE, result.message);
+    spdlog::debug("Auto-build blocked for manufacturing line {}: {}",
+                  manufacturingE.name().c_str(), result.message);
   }
 }
 
-void systemAutoStoreBuiltRocket(flecs::entity manufacturingE,
+void systemAutoStoreBuiltRocket(flecs::entity rocketE, Rocket &rocket,
                                 const Manufacturing &manufacturing) {
   if (!manufacturing.auto_store) {
     return;
   }
-
-  flecs::entity rocket;
-  manufacturingE.children([&](flecs::entity child) {
-    if (child.has<Rocket>() &&
-        child.get<Rocket>().state == RocketStateId::Stored) {
-      rocket = child;
-    }
-  });
-  if (!rocket.is_alive()) {
+  if (rocket.state != RocketStateId::Stored) {
     return;
   }
 
-  flecs::entity storageE = manufacturingE.target<ManufacturingLineStorage>();
+  flecs::entity lineE = rocketE.parent();
+  flecs::entity storageE = lineE.target<ManufacturingLineStorage>();
   if (!storageE.is_valid()) {
     return;
   }
 
-  auto world = manufacturingE.world();
-  RocketMoveAction action{RocketEntity{rocket}, DestinationEntity{storageE}, 1};
+  auto world = rocketE.world();
+  RocketMoveAction action{RocketEntity{rocketE}, DestinationEntity{storageE},
+                          1};
   auto result = action.validate(world);
   if (result.ok) {
-    manufacturingE.remove<AutoStoreBlocked>();
+    lineE.remove<AutoStoreBlocked>();
     action.execute(world);
-  } else if (!manufacturingE.has<AutoStoreBlocked>()) {
-    manufacturingE.add<AutoStoreBlocked>();
-    instantiateBuildingNotification(world, manufacturingE, result.message);
+  } else if (!lineE.has<AutoStoreBlocked>()) {
+    lineE.add<AutoStoreBlocked>();
+    instantiateBuildingNotification(world, lineE, result.message);
+    spdlog::debug("Auto-store blocked for rocket {}: {}",
+                  rocketE.name().c_str(), result.message);
   }
 }

--- a/src/modules/site/site.h
+++ b/src/modules/site/site.h
@@ -41,7 +41,7 @@ struct ManufacturingLineStorage {};
 /// @brief Set when auto_build_next fails validation; cleared when a build
 /// starts again
 struct AutoBuildBlocked {};
-/// @brief Set when auto_store fails validattion; cleared when the validation
+/// @brief Set when auto_store fails validation; cleared when the validation
 /// later succeeds
 struct AutoStoreBlocked {};
 

--- a/src/modules/site/site.h
+++ b/src/modules/site/site.h
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include <flecs.h>
 
+struct Rocket;
+
 /// @brief Tag which the currently displayed Site we're looking at
 struct CurrentSite {};
 
@@ -82,7 +84,7 @@ void systemBuildingUpdateManufacuringProgress(flecs::entity, EffortRequired &,
                                               const Manufacturing &);
 void systemAutoStartNextBuild(flecs::entity manufacturingE,
                               const Manufacturing &);
-void systemAutoStoreBuiltRocket(flecs::entity manufacturingE,
+void systemAutoStoreBuiltRocket(flecs::entity rocketE, Rocket &,
                                 const Manufacturing &);
 
 struct SiteModule {

--- a/src/modules/site/site.h
+++ b/src/modules/site/site.h
@@ -29,14 +29,19 @@ struct Manufacturing {
   uint32_t max_weight = 1000;
   uint32_t available_effort = 50;
   bool auto_build_next = false;
+  bool auto_store = false;
 };
 
 /// @brief Which rocket prefab is being built here, if any
 struct ManufacturingLineTemplate {};
 /// @brief Which storage completed rockets are being stored in, if any
 struct ManufacturingLineStorage {};
-/// @brief Set when auto_build_next fails validation; cleared when a build starts
+/// @brief Set when auto_build_next fails validation; cleared when a build
+/// starts again
 struct AutoBuildBlocked {};
+/// @brief Set when auto_store fails validattion; cleared when the validation
+/// later succeeds
+struct AutoStoreBlocked {};
 
 /// @brief For rockets and payloads
 struct Storage {
@@ -77,6 +82,8 @@ void systemBuildingUpdateManufacuringProgress(flecs::entity, EffortRequired &,
                                               const Manufacturing &);
 void systemAutoStartNextBuild(flecs::entity manufacturingE,
                               const Manufacturing &);
+void systemAutoStoreBuiltRocket(flecs::entity manufacturingE,
+                                const Manufacturing &);
 
 struct SiteModule {
 public:

--- a/src/modules/site/site.h
+++ b/src/modules/site/site.h
@@ -28,7 +28,13 @@ struct Facility {};
 struct Manufacturing {
   uint32_t max_weight = 1000;
   uint32_t available_effort = 50;
+  bool auto_build_next = false;
 };
+
+/// @brief Which rocket prefab is being built here, if any
+struct ManufacturingLineTemplate {};
+/// @brief Which storage completed rockets are being stored in, if any
+struct ManufacturingLineStorage {};
 
 /// @brief For rockets and payloads
 struct Storage {
@@ -67,6 +73,8 @@ void systemCreateSitePrefabs(flecs::iter &);
 void systemCreateSiteWindows(flecs::iter &it);
 void systemBuildingUpdateManufacuringProgress(flecs::entity, EffortRequired &,
                                               const Manufacturing &);
+void systemAutoStartNextBuild(flecs::entity manufacturingE,
+                              const Manufacturing &);
 
 struct SiteModule {
 public:

--- a/src/modules/site/site.h
+++ b/src/modules/site/site.h
@@ -35,6 +35,8 @@ struct Manufacturing {
 struct ManufacturingLineTemplate {};
 /// @brief Which storage completed rockets are being stored in, if any
 struct ManufacturingLineStorage {};
+/// @brief Set when auto_build_next fails validation; cleared when a build starts
+struct AutoBuildBlocked {};
 
 /// @brief For rockets and payloads
 struct Storage {

--- a/src/modules/window/building_detail_window.cpp
+++ b/src/modules/window/building_detail_window.cpp
@@ -14,13 +14,16 @@
 #include "widgets/widgets.h"
 #include <flecs.h>
 #include <flecs/addons/cpp/entity.hpp>
+#include <functional>
 #include <modules/simulation/simulation.h>
 
 void drawManufacturingSection(flecs::entity &entity);
 void drawStorageSection(flecs::entity &entity);
 void drawLaunchpadSection(flecs::entity &entity);
 void drawRocketButtons(flecs::entity &rocket);
-void movePopup(flecs::entity &rocket);
+void storagePickerPopup(const char *popupId, bool open, flecs::world &world,
+                        flecs::entity excluded,
+                        const std::function<void(flecs::entity)> &onConfirm);
 
 void showBuildingDetailWindow(const flecs::entity &entity) {
   spdlog::debug("Showing BuildingDetailWindow");
@@ -120,13 +123,17 @@ void drawManufacturingSection(flecs::entity &entity) {
                                     ? targetStorage.parent().name().c_str()
                                     : "Here");
   ImGui::SameLine();
+  bool openSetStorage = false;
   if (ImGui::SmallButton(targetStorage.is_valid() ? "Clear" : "Set")) {
     if (targetStorage.is_valid()) {
       entity.remove<ManufacturingLineStorage>();
     } else {
-      // TODO: Implement - use prefab?
+      openSetStorage = true;
     }
   }
+  storagePickerPopup(
+      "Set Storage", openSetStorage, world, flecs::entity(),
+      [&](flecs::entity dest) { entity.add<ManufacturingLineStorage>(dest); });
   ImGui::Separator();
 
   // Settings
@@ -154,7 +161,6 @@ void drawManufacturingSection(flecs::entity &entity) {
 }
 
 void drawStorageSection(flecs::entity &entity) {
-  flecs::world world = entity.world();
   entity.children([](flecs::entity rocket) {
     if (!rocket.has<Rocket>()) {
       return;
@@ -205,13 +211,10 @@ void drawRocketButtons(flecs::entity &rocket) {
     issue = "Rocket is not available";
   }
 
-  if (ActionButton(
-          ButtonLabel{.text = "Move"},
-          ButtonTooltip{.text =
-                            "Move the rocket to another storage at this site"},
-          issue)) {
-    ImGui::OpenPopup("Move Rocket");
-  }
+  bool openPopup = ActionButton(
+      ButtonLabel{.text = "Move"},
+      ButtonTooltip{.text = "Move the rocket to another storage at this site"},
+      issue);
   ImGui::SameLine();
 
   auto target = rocket.target<LaunchingOn>();
@@ -227,30 +230,43 @@ void drawRocketButtons(flecs::entity &rocket) {
       showLaunchWindowAdd(rocket.world(), &rocket, nullptr);
     }
   }
-  movePopup(rocket);
+  auto world = rocket.world();
+  auto currentStorage = rocket.parent();
+  auto site = findAncestorWith<Site>(currentStorage);
+  if (site.is_valid()) {
+    constexpr uint8_t moveDurationDays = 2;
+    storagePickerPopup(
+        "Move Rocket", openPopup, world, currentStorage,
+        [&](flecs::entity dest) {
+          RocketMoveAction action{RocketEntity{rocket}, DestinationEntity{dest},
+                                  moveDurationDays};
+          action.execute(world);
+        });
+  }
 }
 
-void movePopup(flecs::entity &rocket) {
-  if (!ImGui::BeginPopupModal("Move Rocket")) {
-    return;
+void storagePickerPopup(const char *popupId, bool open, flecs::world &world,
+                        flecs::entity excluded,
+                        const std::function<void(flecs::entity)> &onConfirm) {
+  static flecs::entity destination;
+  static std::string display = "<Select one>";
+  if (open) {
+    destination = flecs::entity();
+    display = "<Select one>";
+    ImGui::OpenPopup(popupId);
   }
-  auto world = rocket.world();
-  auto source = findAncestorWith<Site>(rocket.parent());
-  if (!source.is_valid()) {
-    spdlog::error("Error: Could not find Site for this rocket");
+  if (!ImGui::BeginPopupModal(popupId)) {
     return;
   }
   ImGui::Text("Where to?");
   ImGui::SameLine();
-  static flecs::entity destination;
-  static std::string display = "<Select one>";
 
   auto storageFacilities =
       world.query_builder().with<Storage>().with<Site>().up().build();
 
   if (ImGui::BeginCombo("##StorageCombo", display.c_str())) {
     storageFacilities.each([&](flecs::entity s) {
-      ImGui::BeginDisabled(s == source);
+      ImGui::BeginDisabled(excluded.is_valid() && s == excluded);
       if (ImGui::Selectable(s.parent().name().c_str(), destination == s)) {
         destination = s;
         display = s.parent().name();
@@ -260,24 +276,20 @@ void movePopup(flecs::entity &rocket) {
     ImGui::EndCombo();
   }
   ImGui::Separator();
-  auto closePopup = [&]() {
-    // Reset variables when closing popup
-    destination = flecs::entity();
-    display = "<Select one>";
-    ImGui::CloseCurrentPopup();
-  };
   if (ImGui::Button("Cancel")) {
-    closePopup();
+    ImGui::CloseCurrentPopup();
   }
   ImGui::SameLine();
-  constexpr uint8_t moveDurationDays = 2;
-  RocketMoveAction action{RocketEntity{rocket}, DestinationEntity{destination},
-                          moveDurationDays};
+  std::string issue;
+  if (!destination.is_valid()) {
+    issue = "Select a destination";
+  } else if (destination == excluded) {
+    issue = "Already here";
+  }
   if (ActionButton(ButtonLabel{.text = "Ok"},
-                   ButtonTooltip{.text = "Move the rocket to the new location"},
-                   action.validate(world).message)) {
-    action.execute(world);
-    closePopup();
+                   ButtonTooltip{.text = "Confirm selection"}, issue)) {
+    onConfirm(destination);
+    ImGui::CloseCurrentPopup();
   }
   ImGui::EndPopup();
 }

--- a/src/modules/window/building_detail_window.cpp
+++ b/src/modules/window/building_detail_window.cpp
@@ -13,6 +13,7 @@
 #include "spdlog/spdlog.h"
 #include "widgets/widgets.h"
 #include <flecs.h>
+#include <flecs/addons/cpp/entity.hpp>
 #include <modules/simulation/simulation.h>
 
 void drawManufacturingSection(flecs::entity &entity);
@@ -92,7 +93,6 @@ void drawManufacturingSection(flecs::entity &entity) {
       e = ch;
     }
   });
-  ImGui::PushID(std::to_string(entity.id()).c_str());
 
   if (e.is_valid()) {
     // There is a rocket on the line
@@ -112,7 +112,24 @@ void drawManufacturingSection(flecs::entity &entity) {
       showRocketPrefabWindow(entity);
     }
   }
-  ImGui::PopID();
+  flecs::entity targetPrefab = entity.target<ManufacturingLineTemplate>();
+  ImGui::Text("Tooled for: %s",
+              targetPrefab.is_valid() ? targetPrefab.name().c_str() : "None");
+
+  ImGui::Separator();
+
+  // Settings
+  auto &manufacturing = entity.get_mut<Manufacturing>();
+  ImGui::Checkbox("Auto Build", &manufacturing.auto_build_next);
+  if (ImGui::BeginItemTooltip()) {
+    ImGui::PushTextWrapPos(ImGui::GetFontSize() * 25.0f);
+    ImGui::TextUnformatted(
+        "If enabled, once the current manufacturing effort is complete, a "
+        "new rocket of the same model will automatically be added to the line "
+        "to be constructed. ");
+    ImGui::PopTextWrapPos();
+    ImGui::EndTooltip();
+  }
 }
 
 void drawStorageSection(flecs::entity &entity) {

--- a/src/modules/window/building_detail_window.cpp
+++ b/src/modules/window/building_detail_window.cpp
@@ -115,7 +115,18 @@ void drawManufacturingSection(flecs::entity &entity) {
   flecs::entity targetPrefab = entity.target<ManufacturingLineTemplate>();
   ImGui::Text("Tooled for: %s",
               targetPrefab.is_valid() ? targetPrefab.name().c_str() : "None");
-
+  flecs::entity targetStorage = entity.target<ManufacturingLineStorage>();
+  ImGui::Text("Stored to: %s ", targetStorage.is_valid()
+                                    ? targetStorage.parent().name().c_str()
+                                    : "Here");
+  ImGui::SameLine();
+  if (ImGui::SmallButton(targetStorage.is_valid() ? "Clear" : "Set")) {
+    if (targetStorage.is_valid()) {
+      entity.remove<ManufacturingLineStorage>();
+    } else {
+      // TODO: Implement - use prefab?
+    }
+  }
   ImGui::Separator();
 
   // Settings
@@ -127,6 +138,16 @@ void drawManufacturingSection(flecs::entity &entity) {
         "If enabled, once the current manufacturing effort is complete, a "
         "new rocket of the same model will automatically be added to the line "
         "to be constructed. ");
+    ImGui::PopTextWrapPos();
+    ImGui::EndTooltip();
+  }
+  ImGui::Checkbox("Auto Store", &manufacturing.auto_store);
+  if (ImGui::BeginItemTooltip()) {
+    ImGui::PushTextWrapPos(ImGui::GetFontSize() * 25.0f);
+    ImGui::TextUnformatted(
+        "If enabled, once the current manufacturing effort is complete, "
+        "the completed rocket will be automatically moved to the selected "
+        "storage ");
     ImGui::PopTextWrapPos();
     ImGui::EndTooltip();
   }
@@ -229,16 +250,12 @@ void movePopup(flecs::entity &rocket) {
 
   if (ImGui::BeginCombo("##StorageCombo", display.c_str())) {
     storageFacilities.each([&](flecs::entity s) {
-      if (s == source) {
-        ImGui::BeginDisabled();
-      }
+      ImGui::BeginDisabled(s == source);
       if (ImGui::Selectable(s.parent().name().c_str(), destination == s)) {
         destination = s;
         display = s.parent().name();
       }
-      if (s == source) {
-        ImGui::EndDisabled();
-      }
+      ImGui::EndDisabled();
     });
     ImGui::EndCombo();
   }

--- a/src/modules/window/building_detail_window.cpp
+++ b/src/modules/window/building_detail_window.cpp
@@ -235,13 +235,13 @@ void drawRocketButtons(flecs::entity &rocket) {
   auto site = findAncestorWith<Site>(currentStorage);
   if (site.is_valid()) {
     constexpr uint8_t moveDurationDays = 2;
-    storagePickerPopup(
-        "Move Rocket", openPopup, world, currentStorage,
-        [&](flecs::entity dest) {
-          RocketMoveAction action{RocketEntity{rocket}, DestinationEntity{dest},
-                                  moveDurationDays};
-          action.execute(world);
-        });
+    storagePickerPopup("Move Rocket", openPopup, world, currentStorage,
+                       [&](flecs::entity dest) {
+                         RocketMoveAction action{RocketEntity{rocket},
+                                                 DestinationEntity{dest},
+                                                 moveDurationDays};
+                         action.execute(world);
+                       });
   }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ add_executable(unit_test
   simulation/update_sim_date.test.cpp
   simulation/generate_sol_system.test.cpp
   site/create_site_prefabs.test.cpp
+  site/auto_start_next_build.test.cpp
   site/manufacturing_progress.test.cpp
   site/rocket_prefab_window/collect_rocket_prefabs.test.cpp
   site/rocket_prefab_window/compute_build_cost.test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,6 +56,7 @@ add_executable(unit_test
   simulation/generate_sol_system.test.cpp
   site/create_site_prefabs.test.cpp
   site/auto_start_next_build.test.cpp
+  site/auto_store_built_rocket.test.cpp
   site/manufacturing_progress.test.cpp
   site/rocket_prefab_window/collect_rocket_prefabs.test.cpp
   site/rocket_prefab_window/compute_build_cost.test.cpp

--- a/test/lua/helpers/add_target_orbit_to_rocket.test.cpp
+++ b/test/lua/helpers/add_target_orbit_to_rocket.test.cpp
@@ -1,6 +1,5 @@
 #include "modules/lua/helpers.h"
 #include "modules/rocket/rocket_module.h"
-#include "setup_helpers.h"
 #include <catch2/catch_test_macros.hpp>
 #include <flecs.h>
 

--- a/test/lua/helpers/create_site.test.cpp
+++ b/test/lua/helpers/create_site.test.cpp
@@ -1,6 +1,5 @@
 #include "modules/lua/helpers.h"
 #include "modules/site/site.h"
-#include "setup_helpers.h"
 #include <catch2/catch_test_macros.hpp>
 #include <flecs.h>
 

--- a/test/rocket/actions/rocket_complete_build_action.test.cpp
+++ b/test/rocket/actions/rocket_complete_build_action.test.cpp
@@ -5,32 +5,56 @@
 #include <catch2/catch_test_macros.hpp>
 #include <flecs.h>
 
-SCENARIO("RocketCompleteBuildAction Block", "[action]") {
+SCENARIO("RocketCompleteBuildAction", "[action]") {
   flecs::world world;
   world.import <SimulationModule>();
   world.import <WindowModule>();
   world.import <RocketModule>();
 
-  GIVEN("A rocket under construction with no effort remaining") {
-    flecs::entity rocket = world.entity().add<Rocket>();
+  GIVEN("An invalid rocket entity") {
+    RocketCompleteBuildAction complete{flecs::entity::null()};
+
+    WHEN("Validated") {
+      ValidationResult result = complete.validate(world);
+
+      THEN("The validation fails") {
+        CHECK(!result.ok);
+        CHECK(result.message == "Rocket is not valid");
+      }
+    }
+  }
+
+  GIVEN("A rocket with no EffortRequired") {
+    auto rocket = world.entity().add<Rocket>();
     rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
-    rocket.set<EffortRequired>({.remaining = 0, .total = 300});
+    RocketCompleteBuildAction complete{rocket};
 
-    WHEN("block is called") {
-      RocketCompleteBuildAction{rocket}.block(world);
+    WHEN("Validated") {
+      ValidationResult result = complete.validate(world);
 
-      THEN("RocketStateTransitionBlocked is not set") {
-        REQUIRE(!rocket.has<RocketStateTransitionBlocked>());
+      THEN("The validation fails") {
+        CHECK(!result.ok);
+        CHECK(result.message == "Does not have any effort required");
       }
     }
   }
 
   GIVEN("A rocket that is not under construction") {
-    flecs::entity rocket = world.entity().add<Rocket>();
+    auto rocket = world.entity().add<Rocket>();
     rocket.set<EffortRequired>({.remaining = 0, .total = 300});
+    RocketCompleteBuildAction complete{rocket};
+
+    WHEN("Validated") {
+      ValidationResult result = complete.validate(world);
+
+      THEN("The validation fails") {
+        CHECK(!result.ok);
+        CHECK(result.message == "Rocket is not under construction");
+      }
+    }
 
     WHEN("block is called") {
-      RocketCompleteBuildAction{rocket}.block(world);
+      complete.block(world);
 
       THEN("RocketStateTransitionBlocked is set with the reason") {
         REQUIRE(rocket.has<RocketStateTransitionBlocked>());
@@ -41,17 +65,80 @@ SCENARIO("RocketCompleteBuildAction Block", "[action]") {
   }
 
   GIVEN("A rocket under construction with effort still remaining") {
-    flecs::entity rocket = world.entity().add<Rocket>();
+    auto rocket = world.entity().add<Rocket>();
     rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
     rocket.set<EffortRequired>({.remaining = 50, .total = 300});
+    RocketCompleteBuildAction complete{rocket};
+
+    WHEN("Validated") {
+      ValidationResult result = complete.validate(world);
+
+      THEN("The validation fails") {
+        CHECK(!result.ok);
+        CHECK(result.message == "Rocket construction is not yet complete");
+      }
+    }
 
     WHEN("block is called") {
-      RocketCompleteBuildAction{rocket}.block(world);
+      complete.block(world);
 
       THEN("RocketStateTransitionBlocked is set with the reason") {
         REQUIRE(rocket.has<RocketStateTransitionBlocked>());
         REQUIRE(rocket.get<RocketStateTransitionBlocked>().reason ==
                 "Rocket construction is not yet complete");
+      }
+    }
+  }
+
+  GIVEN("A rocket ready to complete construction") {
+    auto rocket = world.entity().add<Rocket>();
+    rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
+    rocket.set<EffortRequired>({.remaining = 0, .total = 300});
+    rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
+    RocketCompleteBuildAction complete{rocket};
+
+    WHEN("Validated") {
+      ValidationResult result = complete.validate(world);
+
+      THEN("The validation passes") {
+        CHECK(result.ok);
+        CHECK(result.message == "");
+      }
+    }
+
+    WHEN("block is called") {
+      complete.block(world);
+
+      THEN("RocketStateTransitionBlocked is not set") {
+        REQUIRE(!rocket.has<RocketStateTransitionBlocked>());
+      }
+    }
+
+    WHEN("Executed") {
+      complete.execute(world);
+
+      THEN("The rocket transitions to Stored and construction markers are "
+           "cleared") {
+        CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
+        CHECK(!rocket.has<EffortRequired>());
+        CHECK(!rocket.has<RocketTargetState>());
+      }
+    }
+  }
+
+  GIVEN("A rocket ready to complete construction with a stale "
+        "RocketStateTransitionBlocked marker") {
+    auto rocket = world.entity().add<Rocket>();
+    rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
+    rocket.set<EffortRequired>({.remaining = 0, .total = 300});
+    rocket.set<RocketStateTransitionBlocked>({.reason = "stale"});
+    RocketCompleteBuildAction complete{rocket};
+
+    WHEN("Executed") {
+      complete.execute(world);
+
+      THEN("RocketStateTransitionBlocked is cleared") {
+        CHECK(!rocket.has<RocketStateTransitionBlocked>());
       }
     }
   }

--- a/test/rocket/actions/rocket_complete_move_action.test.cpp
+++ b/test/rocket/actions/rocket_complete_move_action.test.cpp
@@ -51,6 +51,16 @@ SCENARIO("RocketCompleteMoveAction", "[action]") {
         CHECK(result.message == "Rocket does not have a valid target");
       }
     }
+
+    WHEN("block is called") {
+      complete.block(world);
+
+      THEN("RocketStateTransitionBlocked is set with the reason") {
+        REQUIRE(rocket.has<RocketStateTransitionBlocked>());
+        CHECK(rocket.get<RocketStateTransitionBlocked>().reason ==
+              "Rocket does not have a valid target");
+      }
+    }
   }
 
   GIVEN("A moving rocket with time remaining") {
@@ -90,6 +100,14 @@ SCENARIO("RocketCompleteMoveAction", "[action]") {
       }
     }
 
+    WHEN("block is called") {
+      complete.block(world);
+
+      THEN("RocketStateTransitionBlocked is not set") {
+        CHECK(!rocket.has<RocketStateTransitionBlocked>());
+      }
+    }
+
     WHEN("Executed") {
       complete.execute(world);
 
@@ -102,40 +120,23 @@ SCENARIO("RocketCompleteMoveAction", "[action]") {
       }
     }
   }
-}
 
-SCENARIO("RocketCompleteMoveAction Block", "[action]") {
-  flecs::world world;
-  world.import <SimulationModule>();
-  world.import <WindowModule>();
-  world.import <RocketModule>();
-
-  GIVEN("A rocket that can complete move") {
+  GIVEN("A completed move with a stale RocketStateTransitionBlocked marker") {
+    auto source = world.entity();
     auto destination = world.entity();
-    auto rocket = world.entity().add<Rocket>();
+    auto rocket = world.entity().add<Rocket>().child_of(source);
     rocket.get_mut<Rocket>().state = RocketStateId::Moving;
+    rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
     rocket.add<RocketTargetParent>(destination);
+    rocket.set<DurationRequired>({.remaining = 0, .total = 5});
+    rocket.set<RocketStateTransitionBlocked>({.reason = "stale"});
+    RocketCompleteMoveAction complete{rocket};
 
-    WHEN("block is called") {
-      RocketCompleteMoveAction{rocket}.block(world);
+    WHEN("Executed") {
+      complete.execute(world);
 
-      THEN("RocketStateTransitionBlocked is not set") {
+      THEN("RocketStateTransitionBlocked is cleared") {
         CHECK(!rocket.has<RocketStateTransitionBlocked>());
-      }
-    }
-  }
-
-  GIVEN("A rocket missing move target") {
-    auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::Moving;
-
-    WHEN("block is called") {
-      RocketCompleteMoveAction{rocket}.block(world);
-
-      THEN("RocketStateTransitionBlocked is set with the reason") {
-        REQUIRE(rocket.has<RocketStateTransitionBlocked>());
-        CHECK(rocket.get<RocketStateTransitionBlocked>().reason ==
-              "Rocket does not have a valid target");
       }
     }
   }

--- a/test/rocket/actions/rocket_move_action.test.cpp
+++ b/test/rocket/actions/rocket_move_action.test.cpp
@@ -72,7 +72,7 @@ SCENARIO("RocketMoveAction", "[action]") {
 
       THEN("The validation fails") {
         CHECK(!result);
-        CHECK(result.message == "Rocket is not stored already");
+        CHECK(result.message == "Rocket must be currently stored to be moved");
       }
     }
   }

--- a/test/rocket/actions/rocket_move_action.test.cpp
+++ b/test/rocket/actions/rocket_move_action.test.cpp
@@ -72,7 +72,7 @@ SCENARIO("RocketMoveAction", "[action]") {
 
       THEN("The validation fails") {
         CHECK(!result);
-        CHECK(result.message == "Rocket is under construction");
+        CHECK(result.message == "Rocket is not stored already");
       }
     }
   }

--- a/test/rocket/systems.test.cpp
+++ b/test/rocket/systems.test.cpp
@@ -209,7 +209,7 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
     rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
 
     WHEN("systemRocketCompleteAction is called") {
-      systemRocketCompleteAction(rocket);
+      systemRocketCompleteAction(rocket, rocket.get_mut<Rocket>());
 
       THEN("The rocket is blocked and remains under construction") {
         CHECK(rocket.get<Rocket>().state == RocketStateId::UnderConstruction);
@@ -228,7 +228,7 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
     rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
 
     WHEN("systemRocketCompleteAction is called") {
-      systemRocketCompleteAction(rocket);
+      systemRocketCompleteAction(rocket, rocket.get_mut<Rocket>());
 
       THEN("The rocket transitions to Stored and EffortRequired is removed") {
         CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
@@ -243,7 +243,7 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
     rocket.set<EffortRequired>({.remaining = 0, .total = 300});
 
     WHEN("systemRocketCompleteAction is called") {
-      systemRocketCompleteAction(rocket);
+      systemRocketCompleteAction(rocket, rocket.get_mut<Rocket>());
 
       THEN("Nothing happens — the system ignores states other than "
            "UnderConstruction and Moving") {
@@ -264,7 +264,7 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
     rocket.set<DurationRequired>({.remaining = 3, .total = 5});
 
     WHEN("systemRocketCompleteAction is called") {
-      systemRocketCompleteAction(rocket);
+      systemRocketCompleteAction(rocket, rocket.get_mut<Rocket>());
 
       THEN("The rocket is blocked and remains at its current location") {
         CHECK(rocket.parent() == source);
@@ -287,7 +287,7 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
     rocket.set<DurationRequired>({.remaining = 0, .total = 5});
 
     WHEN("systemRocketCompleteAction is called") {
-      systemRocketCompleteAction(rocket);
+      systemRocketCompleteAction(rocket, rocket.get_mut<Rocket>());
 
       THEN("The rocket is reparented to its destination and move markers are "
            "cleared") {

--- a/test/site/auto_start_next_build.test.cpp
+++ b/test/site/auto_start_next_build.test.cpp
@@ -6,9 +6,9 @@
 
 SCENARIO("systemAutoStartNextBuild", "[system]") {
   flecs::world world;
-  world.import<SimulationModule>();
-  world.import<SiteModule>();
-  world.import<RocketModule>();
+  world.import <SimulationModule>();
+  world.import <SiteModule>();
+  world.import <RocketModule>();
 
   auto makeLine = [&](bool auto_build) {
     return world.entity().set<Manufacturing>(
@@ -33,9 +33,7 @@ SCENARIO("systemAutoStartNextBuild", "[system]") {
     WHEN("systemAutoStartNextBuild runs") {
       systemAutoStartNextBuild(line, line.get<Manufacturing>());
 
-      THEN("no rocket is started") {
-        CHECK(countRocketChildren(line) == 0);
-      }
+      THEN("no rocket is started") { CHECK(countRocketChildren(line) == 0); }
     }
   }
 
@@ -46,9 +44,7 @@ SCENARIO("systemAutoStartNextBuild", "[system]") {
     WHEN("systemAutoStartNextBuild runs") {
       systemAutoStartNextBuild(line, line.get<Manufacturing>());
 
-      THEN("no rocket is started") {
-        CHECK(countRocketChildren(line) == 0);
-      }
+      THEN("no rocket is started") { CHECK(countRocketChildren(line) == 0); }
     }
   }
 
@@ -69,7 +65,8 @@ SCENARIO("systemAutoStartNextBuild", "[system]") {
     }
   }
 
-  GIVEN("auto_build_next is true, template set, line is free, insufficient balance") {
+  GIVEN("auto_build_next is true, template set, line is free, insufficient "
+        "balance") {
     auto prefab = world.prefab().add<Rocket>();
     auto line = makeLine(true);
     line.add<ManufacturingLineTemplate>(prefab);
@@ -82,9 +79,7 @@ SCENARIO("systemAutoStartNextBuild", "[system]") {
         CHECK(line.has<AutoBuildBlocked>());
       }
 
-      THEN("no rocket is started") {
-        CHECK(countRocketChildren(line) == 0);
-      }
+      THEN("no rocket is started") { CHECK(countRocketChildren(line) == 0); }
     }
 
     WHEN("systemAutoStartNextBuild runs repeatedly") {
@@ -92,13 +87,15 @@ SCENARIO("systemAutoStartNextBuild", "[system]") {
       systemAutoStartNextBuild(line, line.get<Manufacturing>());
       systemAutoStartNextBuild(line, line.get<Manufacturing>());
 
-      THEN("the line remains blocked without spawning duplicate notifications") {
+      THEN(
+          "the line remains blocked without spawning duplicate notifications") {
         CHECK(line.has<AutoBuildBlocked>());
       }
     }
   }
 
-  GIVEN("auto_build_next is true, template set, line is free, sufficient balance") {
+  GIVEN("auto_build_next is true, template set, line is free, sufficient "
+        "balance") {
     auto prefab = world.prefab().add<Rocket>();
     auto line = makeLine(true);
     line.add<ManufacturingLineTemplate>(prefab);

--- a/test/site/auto_start_next_build.test.cpp
+++ b/test/site/auto_start_next_build.test.cpp
@@ -75,11 +75,25 @@ SCENARIO("systemAutoStartNextBuild", "[system]") {
     line.add<ManufacturingLineTemplate>(prefab);
     world.get_mut<Company>().balance = 0;
 
-    WHEN("systemAutoStartNextBuild runs") {
+    WHEN("systemAutoStartNextBuild runs once") {
       systemAutoStartNextBuild(line, line.get<Manufacturing>());
+
+      THEN("the line is marked as blocked") {
+        CHECK(line.has<AutoBuildBlocked>());
+      }
 
       THEN("no rocket is started") {
         CHECK(countRocketChildren(line) == 0);
+      }
+    }
+
+    WHEN("systemAutoStartNextBuild runs repeatedly") {
+      systemAutoStartNextBuild(line, line.get<Manufacturing>());
+      systemAutoStartNextBuild(line, line.get<Manufacturing>());
+      systemAutoStartNextBuild(line, line.get<Manufacturing>());
+
+      THEN("the line remains blocked without spawning duplicate notifications") {
+        CHECK(line.has<AutoBuildBlocked>());
       }
     }
   }
@@ -107,6 +121,27 @@ SCENARIO("systemAutoStartNextBuild", "[system]") {
 
       THEN("the cost is deducted from the company balance") {
         CHECK(world.get<Company>().balance < 10'000'000);
+      }
+
+      THEN("the AutoBuildBlocked tag is cleared") {
+        CHECK(!line.has<AutoBuildBlocked>());
+      }
+    }
+  }
+
+  GIVEN("a line that was previously blocked, and funds are now available") {
+    auto prefab = world.prefab().add<Rocket>();
+    auto line = makeLine(true);
+    line.add<ManufacturingLineTemplate>(prefab);
+    line.add<AutoBuildBlocked>();
+    world.get_mut<Company>().balance = 10'000'000;
+
+    WHEN("systemAutoStartNextBuild runs") {
+      systemAutoStartNextBuild(line, line.get<Manufacturing>());
+
+      THEN("a rocket is started and the blocked tag is cleared") {
+        CHECK(countRocketChildren(line) == 1);
+        CHECK(!line.has<AutoBuildBlocked>());
       }
     }
   }

--- a/test/site/auto_start_next_build.test.cpp
+++ b/test/site/auto_start_next_build.test.cpp
@@ -1,0 +1,113 @@
+#include "modules/rocket/rocket_module.h"
+#include "modules/simulation/simulation.h"
+#include "modules/site/site.h"
+#include <catch2/catch_test_macros.hpp>
+#include <flecs.h>
+
+SCENARIO("systemAutoStartNextBuild", "[system]") {
+  flecs::world world;
+  world.import<SimulationModule>();
+  world.import<SiteModule>();
+  world.import<RocketModule>();
+
+  auto makeLine = [&](bool auto_build) {
+    return world.entity().set<Manufacturing>(
+        {.available_effort = 50, .auto_build_next = auto_build});
+  };
+
+  auto countRocketChildren = [](flecs::entity line) {
+    int count = 0;
+    line.children([&](flecs::entity child) {
+      if (child.has<Rocket>())
+        count++;
+    });
+    return count;
+  };
+
+  GIVEN("auto_build_next is false") {
+    auto prefab = world.prefab().add<Rocket>();
+    auto line = makeLine(false);
+    line.add<ManufacturingLineTemplate>(prefab);
+    world.get_mut<Company>().balance = 10'000'000;
+
+    WHEN("systemAutoStartNextBuild runs") {
+      systemAutoStartNextBuild(line, line.get<Manufacturing>());
+
+      THEN("no rocket is started") {
+        CHECK(countRocketChildren(line) == 0);
+      }
+    }
+  }
+
+  GIVEN("auto_build_next is true but no template is set") {
+    auto line = makeLine(true);
+    world.get_mut<Company>().balance = 10'000'000;
+
+    WHEN("systemAutoStartNextBuild runs") {
+      systemAutoStartNextBuild(line, line.get<Manufacturing>());
+
+      THEN("no rocket is started") {
+        CHECK(countRocketChildren(line) == 0);
+      }
+    }
+  }
+
+  GIVEN("auto_build_next is true, template set, line already has a rocket") {
+    auto prefab = world.prefab().add<Rocket>();
+    auto line = makeLine(true);
+    line.add<ManufacturingLineTemplate>(prefab);
+    world.get_mut<Company>().balance = 10'000'000;
+
+    world.entity().add<Rocket>().child_of(line);
+
+    WHEN("systemAutoStartNextBuild runs") {
+      systemAutoStartNextBuild(line, line.get<Manufacturing>());
+
+      THEN("no new rocket is started") {
+        CHECK(countRocketChildren(line) == 1);
+      }
+    }
+  }
+
+  GIVEN("auto_build_next is true, template set, line is free, insufficient balance") {
+    auto prefab = world.prefab().add<Rocket>();
+    auto line = makeLine(true);
+    line.add<ManufacturingLineTemplate>(prefab);
+    world.get_mut<Company>().balance = 0;
+
+    WHEN("systemAutoStartNextBuild runs") {
+      systemAutoStartNextBuild(line, line.get<Manufacturing>());
+
+      THEN("no rocket is started") {
+        CHECK(countRocketChildren(line) == 0);
+      }
+    }
+  }
+
+  GIVEN("auto_build_next is true, template set, line is free, sufficient balance") {
+    auto prefab = world.prefab().add<Rocket>();
+    auto line = makeLine(true);
+    line.add<ManufacturingLineTemplate>(prefab);
+    world.get_mut<Company>().balance = 10'000'000;
+
+    WHEN("systemAutoStartNextBuild runs") {
+      systemAutoStartNextBuild(line, line.get<Manufacturing>());
+
+      THEN("a rocket is created as a child of the line under construction") {
+        REQUIRE(countRocketChildren(line) == 1);
+        flecs::entity created = flecs::entity::null();
+        line.children([&](flecs::entity child) {
+          if (child.has<Rocket>())
+            created = child;
+        });
+        REQUIRE(created.is_valid());
+        CHECK(created.get<Rocket>().state == RocketStateId::UnderConstruction);
+        CHECK(created.has<EffortRequired>());
+      }
+
+      THEN("the cost is deducted from the company balance") {
+        CHECK(world.get<Company>().balance < 10'000'000);
+      }
+    }
+  }
+}

--- a/test/site/auto_store_built_rocket.test.cpp
+++ b/test/site/auto_store_built_rocket.test.cpp
@@ -1,0 +1,151 @@
+#include "modules/rocket/rocket_module.h"
+#include "modules/simulation/simulation.h"
+#include "modules/site/site.h"
+#include <catch2/catch_test_macros.hpp>
+#include <flecs.h>
+
+SCENARIO("systemAutoStoreBuiltRocket", "[system]") {
+  flecs::world world;
+  world.import <SimulationModule>();
+  world.import <SiteModule>();
+  world.import <RocketModule>();
+
+  auto makeLine = [&](bool auto_store) {
+    return world.entity().set<Manufacturing>(
+        {.available_effort = 50, .auto_store = auto_store});
+  };
+
+  auto makeStorage = [&]() { return world.entity().add<Storage>(); };
+
+  auto addStoredRocketChild = [&](flecs::entity line) {
+    auto rocket = world.entity().add<Rocket>().child_of(line);
+    rocket.get_mut<Rocket>().state = RocketStateId::Stored;
+    return rocket;
+  };
+
+  auto callSystem = [](flecs::entity rocketE, const Manufacturing &mfg) {
+    systemAutoStoreBuiltRocket(rocketE, rocketE.get_mut<Rocket>(), mfg);
+  };
+
+  GIVEN("auto_store is false") {
+    auto storage = makeStorage();
+    auto line = makeLine(false);
+    line.add<ManufacturingLineStorage>(storage);
+    auto rocket = addStoredRocketChild(line);
+
+    WHEN("systemAutoStoreBuiltRocket runs") {
+      callSystem(rocket, line.get<Manufacturing>());
+
+      THEN("the rocket is not moved") {
+        CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
+        CHECK(rocket.parent() == line);
+      }
+    }
+  }
+
+  GIVEN("auto_store is true but rocket is under construction") {
+    auto storage = makeStorage();
+    auto line = makeLine(true);
+    line.add<ManufacturingLineStorage>(storage);
+
+    auto rocket = world.entity().add<Rocket>().child_of(line);
+    rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
+
+    WHEN("systemAutoStoreBuiltRocket runs") {
+      callSystem(rocket, line.get<Manufacturing>());
+
+      THEN("the rocket is not moved") {
+        CHECK(rocket.get<Rocket>().state == RocketStateId::UnderConstruction);
+        CHECK(rocket.parent() == line);
+      }
+    }
+  }
+
+  GIVEN("auto_store is true, rocket is stored, but no storage destination is "
+        "set") {
+    auto line = makeLine(true);
+    auto rocket = addStoredRocketChild(line);
+
+    WHEN("systemAutoStoreBuiltRocket runs") {
+      callSystem(rocket, line.get<Manufacturing>());
+
+      THEN("the rocket is not moved") {
+        CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
+        CHECK(rocket.parent() == line);
+      }
+    }
+  }
+
+  GIVEN(
+      "auto_store is true, a stored rocket exists, and storage is configured") {
+    auto storage = makeStorage();
+    auto line = makeLine(true);
+    line.add<ManufacturingLineStorage>(storage);
+    auto rocket = addStoredRocketChild(line);
+
+    WHEN("systemAutoStoreBuiltRocket runs") {
+      callSystem(rocket, line.get<Manufacturing>());
+
+      THEN("the rocket transitions to Moving") {
+        CHECK(rocket.get<Rocket>().state == RocketStateId::Moving);
+      }
+
+      THEN("AutoStoreBlocked is cleared") {
+        CHECK(!line.has<AutoStoreBlocked>());
+      }
+    }
+  }
+
+  GIVEN("auto_store is true but the rocket still has EffortRequired "
+        "(deferred-command race)") {
+    auto storage = makeStorage();
+    auto line = makeLine(true);
+    line.add<ManufacturingLineStorage>(storage);
+
+    // Simulate the race: state is Stored (immediate write from
+    // RocketCompleteBuildAction) but EffortRequired removal is still pending
+    // (deferred structural change).
+    auto rocket = addStoredRocketChild(line);
+    rocket.set<EffortRequired>({.remaining = 0, .total = 300});
+
+    WHEN("systemAutoStoreBuiltRocket runs") {
+      callSystem(rocket, line.get<Manufacturing>());
+
+      THEN("the rocket is not moved") {
+        CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
+        CHECK(rocket.parent() == line);
+      }
+
+      THEN("the line is marked as blocked") {
+        CHECK(line.has<AutoStoreBlocked>());
+      }
+    }
+
+    WHEN("systemAutoStoreBuiltRocket runs repeatedly") {
+      callSystem(rocket, line.get<Manufacturing>());
+      callSystem(rocket, line.get<Manufacturing>());
+      callSystem(rocket, line.get<Manufacturing>());
+
+      THEN("the line stays blocked without spawning duplicate notifications") {
+        CHECK(line.has<AutoStoreBlocked>());
+      }
+    }
+  }
+
+  GIVEN("a previously blocked line where EffortRequired is now gone") {
+    auto storage = makeStorage();
+    auto line = makeLine(true);
+    line.add<ManufacturingLineStorage>(storage);
+    line.add<AutoStoreBlocked>();
+    auto rocket = addStoredRocketChild(line);
+
+    WHEN("systemAutoStoreBuiltRocket runs") {
+      callSystem(rocket, line.get<Manufacturing>());
+
+      THEN("the blocked tag is cleared and the rocket begins moving") {
+        CHECK(!line.has<AutoStoreBlocked>());
+        CHECK(rocket.get<Rocket>().state == RocketStateId::Moving);
+      }
+    }
+  }
+}

--- a/test/site/rocket_prefab_window/compute_build_cost.test.cpp
+++ b/test/site/rocket_prefab_window/compute_build_cost.test.cpp
@@ -1,5 +1,4 @@
 #include "modules/rocket/rocket_module.h"
-#include "modules/simulation/simulation.h"
 #include "modules/site/rocket_prefab_window.h"
 #include "modules/stats/stats.h"
 #include <catch2/catch_test_macros.hpp>


### PR DESCRIPTION
feat(rocket): When a manufacturing line is done it can automatically repeat the same build

- When a rocket is being selected, the manufacturing line is "tooled" to that model (this currently has no further gameplay impact - currently!)
- When the rocket is finished and the line is clear, it will automatically start the same rocket model again if there are sufficient funds
- When the rocket is finished and the auto-move checkbox is set, the rocket will move to a pre-selected storage location