### PR TITLE
feat(window): Notification Window

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ list(APPEND SolCorpSources
     modules/window/window_module.cpp
     modules/window/main_menu.cpp
     modules/window/building_detail_window.cpp
+    modules/window/notification_window.cpp
     modules/rocket/rocket_module.cpp
     modules/rocket/actions.cpp
     modules/rocket/launch_window.cpp
@@ -53,6 +54,7 @@ list(APPEND SolCorpHeaders
     modules/window/window_module.h
     modules/window/main_menu.h
     modules/window/building_detail_window.h
+    modules/window/notification_window.h
     modules/rocket/rocket_module.h
     modules/rocket/actions.h
     modules/rocket/launch_window.h

--- a/src/modules/base/notification.cpp
+++ b/src/modules/base/notification.cpp
@@ -1,4 +1,6 @@
 #include "notification.h"
+
+uint32_t Notification::max_id = 0;
 #include "modules/lua/lua.h"
 #include <spdlog/spdlog.h>
 
@@ -56,8 +58,10 @@ flecs::entity instantiateNotification(flecs::world &world,
     notificationsNode = world.entity("Notifications");
   }
   auto e = world.entity()
-               .set<Notification>(
-                   {.title = title, .text = text, .severity = severity})
+               .set<Notification>({.id = Notification::max_id++,
+                                   .title = title,
+                                   .text = text,
+                                   .severity = severity})
                .child_of(notificationsNode);
 
   category = category.is_valid() ? category

--- a/src/modules/base/notification.cpp
+++ b/src/modules/base/notification.cpp
@@ -24,7 +24,7 @@ void registerNotificationComponents(flecs::world &world) {
   });
 }
 
-std::string_view to_string(NotificationSeverity severity) {
+const char *to_string(NotificationSeverity severity) {
   switch (severity) {
   case NotificationSeverity::Low:
     return "Low";

--- a/src/modules/base/notification.cpp
+++ b/src/modules/base/notification.cpp
@@ -14,6 +14,7 @@ void registerNotificationComponents(flecs::world &world) {
   world.component<NotificationCategory>().add(flecs::Exclusive);
   world.component<NotificationRead>();
   world.component<Notification>()
+      .member("id", &Notification::id)
       .member("title", &Notification::title)
       .member("text", &Notification::text)
       .member("severity", &Notification::severity);

--- a/src/modules/base/notification.h
+++ b/src/modules/base/notification.h
@@ -27,7 +27,7 @@ struct NotificationCategory {};
 /// @brief Tag to indicate a notification has been read by the player.
 struct NotificationRead {};
 
-std::string_view to_string(NotificationSeverity severity);
+const char *to_string(NotificationSeverity severity);
 
 void registerNotificationComponents(flecs::world &world);
 

--- a/src/modules/base/notification.h
+++ b/src/modules/base/notification.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <flecs.h>
 #include <string>
 

--- a/src/modules/base/notification.h
+++ b/src/modules/base/notification.h
@@ -14,6 +14,8 @@ enum class NotificationSeverity : uint8_t {
 
 /// @brief Component representing a notification to be shown to the player.
 struct Notification {
+  static uint32_t max_id;
+  uint32_t id = 0;
   std::string title;
   std::string text;
   NotificationSeverity severity = NotificationSeverity::Low;

--- a/src/modules/lua/helpers.cpp
+++ b/src/modules/lua/helpers.cpp
@@ -1,5 +1,6 @@
 #include "helpers.h"
 #include "modules/base/assert.h"
+#include "modules/base/notification.h"
 #include "modules/engine/render.h"
 #include "modules/lua/entity.h"
 #include "modules/lua/lua_registry.h"
@@ -144,10 +145,11 @@ Sprite clip_sprite_from_texture(const flecs::world &world,
   return sprite;
 }
 
-flecs::entity
-create_contract(const flecs::world &world, const std::string &name,
-                const std::string &client, const std::string &description,
-                uint32_t upfront_payment, uint32_t completion_payment) {
+flecs::entity create_contract(flecs::world &world, const std::string &name,
+                              const std::string &client,
+                              const std::string &description,
+                              uint32_t upfront_payment,
+                              uint32_t completion_payment) {
   auto contracts_node = world.lookup("Contracts");
   SC_ASSERT(contracts_node.is_valid(), "Contracts node not found");
   auto existing = contracts_node.lookup(name.c_str());
@@ -155,6 +157,10 @@ create_contract(const flecs::world &world, const std::string &name,
     spdlog::warn("Entity with name {} already exists", name);
     return existing;
   }
+  instantiateNotification(world, "Contract Created",
+                          fmt::format("A new contract '{}' is available", name),
+                          world.lookup("NotificationCategories::Contracts"),
+                          NotificationSeverity::Medium);
   return world.entity(name.c_str())
       .set<Contract>({.client = client,
                       .description = description,

--- a/src/modules/lua/helpers.h
+++ b/src/modules/lua/helpers.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "modules/engine/render.h"
-#include "modules/rocket/rocket_module.h"
 #include "modules/stats/stats.h"
 #include <flecs.h>
 #include <lua.hpp>
@@ -62,10 +61,11 @@ flecs::entity add_modifier(const flecs::world &world, flecs::entity effect,
 Sprite clip_sprite_from_texture(const flecs::world &world,
                                 const std::string &texture,
                                 SpriteClipRect rect);
-flecs::entity
-create_contract(const flecs::world &world, const std::string &name,
-                const std::string &client, const std::string &description,
-                uint32_t upfront_payment, uint32_t completion_payment);
+flecs::entity create_contract(flecs::world &world, const std::string &name,
+                              const std::string &client,
+                              const std::string &description,
+                              uint32_t upfront_payment,
+                              uint32_t completion_payment);
 flecs::entity create_contract_payload(const flecs::world &world,
                                       flecs::entity contract,
                                       const std::string &name, uint32_t mass,

--- a/src/modules/rocket/actions.cpp
+++ b/src/modules/rocket/actions.cpp
@@ -272,9 +272,13 @@ void RocketCompleteBuildAction::block(flecs::world &world) {
     return;
   }
 
+  if (!rocket.has<RocketStateTransitionBlocked>()) {
+    instantiateNotification(
+        world, "Rocket cannot be completed", result.message,
+        world.lookup("NotificationCategories::Rocket Build"),
+        NotificationSeverity::Important);
+  }
   this->rocket.set<RocketStateTransitionBlocked>({.reason = result.message});
-  spdlog::debug("Blocking rocket build completion for rocket {}: {}",
-                this->rocket.name().c_str(), result.message);
 }
 
 // ----- RocketMoveAction-----
@@ -339,6 +343,13 @@ void RocketCompleteMoveAction::execute(flecs::world &world) {
     return;
   }
   auto targetParent = rocket.target<RocketTargetParent>();
+  instantiateNotification(world, "Rocket move completed",
+                          std::format("{} has been moved to {}",
+                                      rocket.name().c_str(),
+                                      targetParent.name().c_str()),
+                          world.lookup("NotificationCategories::Rocket Move"),
+                          NotificationSeverity::Low);
+
   rocket.child_of(targetParent);
   rocket.get_mut<Rocket>().state = rocket.get<RocketTargetState>().target;
   rocket.remove<RocketTargetState>();
@@ -353,7 +364,10 @@ void RocketCompleteMoveAction::block(flecs::world &world) {
     return;
   }
 
+  if (!rocket.has<RocketStateTransitionBlocked>()) {
+    instantiateNotification(world, "Rocket cannot move", result.message,
+                            world.lookup("NotificationCategories::Rocket Move"),
+                            NotificationSeverity::Important);
+  }
   this->rocket.set<RocketStateTransitionBlocked>({.reason = result.message});
-  spdlog::debug("Blocking rocket move completion for rocket {}: {}",
-                this->rocket.name().c_str(), result.message);
 }

--- a/src/modules/rocket/actions.cpp
+++ b/src/modules/rocket/actions.cpp
@@ -6,6 +6,7 @@
 #include "modules/site/site.h"
 #include "rocket_module.h"
 #include <flecs.h>
+#include <format>
 #include <spdlog/spdlog.h>
 
 ValidationResult

--- a/src/modules/rocket/actions.cpp
+++ b/src/modules/rocket/actions.cpp
@@ -235,14 +235,10 @@ RocketCompleteBuildAction::validate(const flecs::world &) const {
   if (!rocket.is_valid()) {
     return ValidationResult::Fail("Rocket is not valid");
   }
-  if (!rocket.has<EffortRequired>()) {
-    return ValidationResult::Fail("Does not have any effort required");
-  }
   if (rocket.get<Rocket>().state != RocketStateId::UnderConstruction) {
     return ValidationResult::Fail("Rocket is not under construction");
   }
-  auto effort = rocket.get<EffortRequired>();
-  if (effort.remaining > 0) {
+  if (rocket.has<EffortRequired>()) {
     return ValidationResult::Fail("Rocket construction is not yet complete");
   }
   // TODO: Check there's enough storage space for the new rocket
@@ -255,7 +251,6 @@ void RocketCompleteBuildAction::execute(flecs::world &world) {
   }
 
   rocket.get_mut<Rocket>().state = RocketStateId::Stored;
-  rocket.remove<EffortRequired>();
   rocket.remove<RocketTargetState>();
   rocket.remove<RocketStateTransitionBlocked>();
 
@@ -330,8 +325,7 @@ RocketCompleteMoveAction::validate(const flecs::world &) const {
   if (!rocket.target<RocketTargetParent>().is_valid()) {
     return ValidationResult::Fail("Rocket does not have a valid target");
   }
-  if (rocket.has<DurationRequired>() &&
-      rocket.get<DurationRequired>().remaining > 0) {
+  if (rocket.has<DurationRequired>()) {
     return ValidationResult::Fail(
         "Rocket has not yet moved to the new location");
   }
@@ -354,7 +348,6 @@ void RocketCompleteMoveAction::execute(flecs::world &world) {
   rocket.get_mut<Rocket>().state = rocket.get<RocketTargetState>().target;
   rocket.remove<RocketTargetState>();
   rocket.remove<RocketTargetParent>();
-  rocket.remove<DurationRequired>();
   rocket.remove<RocketStateTransitionBlocked>();
 }
 

--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -312,6 +312,12 @@ void systemCreateRocketPrefabs(flecs::iter &it) {
 
 void systemRocketCompleteAction(flecs::entity e, Rocket &rocket) {
   auto world = e.world();
+
+  if (e.has<EffortRequired>() && e.get<EffortRequired>().remaining > 0)
+    return;
+  if (e.has<DurationRequired>() && e.get<DurationRequired>().remaining > 0)
+    return;
+
   std::unique_ptr<IAction> action;
 
   switch (rocket.state) {

--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -185,9 +185,8 @@ RocketModule::RocketModule(flecs::world &world) {
       .immediate()
       .tick_source(sim.speed)
       .with<RocketTargetState>()
-      .with<DurationRequired>()
-      .oper(flecs::Or)
-      .with<EffortRequired>()
+      .without<EffortRequired>()
+      .without<DurationRequired>()
       .kind(UpdatePhase)
       .each(systemRocketCompleteAction);
 }
@@ -312,11 +311,6 @@ void systemCreateRocketPrefabs(flecs::iter &it) {
 
 void systemRocketCompleteAction(flecs::entity e, Rocket &rocket) {
   auto world = e.world();
-
-  if (e.has<EffortRequired>() && e.get<EffortRequired>().remaining > 0)
-    return;
-  if (e.has<DurationRequired>() && e.get<DurationRequired>().remaining > 0)
-    return;
 
   std::unique_ptr<IAction> action;
 

--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -269,13 +269,14 @@ void systemLaunchRocket(flecs::entity planE, LaunchPlan &plan) {
   std::string notification =
       rocket_failure ? std::format("{} failed - {} exploded on launch",
                                    planE.name().c_str(), rocketE.name().c_str())
-                     : std::format("{} launched successfully (${})",
-                                   planE.name().c_str(), total_payment);
+                     : std::format("{} launched {} successfully (${})",
+                                   planE.name().c_str(), rocketE.name().c_str(),
+                                   total_payment);
   instantiateBuildingNotification(world, launchpadE, notification);
   instantiateNotification(world, "Launch Complete", notification,
                           world.lookup("NotificationCategories::Rocket Launch"),
-                          rocket_failure ? NotificationSeverity::High
-                                         : NotificationSeverity::Low);
+                          rocket_failure ? NotificationSeverity::Critical
+                                         : NotificationSeverity::High);
   rocketE.destruct();
   planE.destruct();
 }
@@ -284,6 +285,7 @@ void systemCreateRocketBuildCategory(flecs::iter &it) {
   auto world = it.world();
   createNotificationCategory(world, "Rocket Build");
   createNotificationCategory(world, "Rocket Launch");
+  createNotificationCategory(world, "Rocket Move");
   createNotificationCategory(world, "Contracts");
 }
 

--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -250,11 +250,12 @@ void systemLaunchRocket(flecs::entity planE, LaunchPlan &plan) {
         contract.failed = false;
         company.balance += static_cast<int64_t>(contract.completion_payment);
         total_payment += contract.completion_payment;
-        instantiateNotification(world, "Payload Launched",
-                                fmt::format("{} was launched on {} to {}",
-                                            payload.name().c_str(),
-                                            rocketE.name().c_str(),
-                                            plan.target_orbit.name().c_str()));
+        instantiateNotification(
+            world, "Payload Launched",
+            fmt::format("{} was launched on {} to {}", payload.name().c_str(),
+                        rocketE.name().c_str(),
+                        plan.target_orbit.name().c_str()),
+            world.lookup("NotificationCategories::Rocket Launch"));
       }
       contract.status = ContractStatus::Closed;
 
@@ -272,7 +273,7 @@ void systemLaunchRocket(flecs::entity planE, LaunchPlan &plan) {
                                    planE.name().c_str(), total_payment);
   instantiateBuildingNotification(world, launchpadE, notification);
   instantiateNotification(world, "Launch Complete", notification,
-                          world.lookup("NotificationCategories::Rocket Build"),
+                          world.lookup("NotificationCategories::Rocket Launch"),
                           rocket_failure ? NotificationSeverity::High
                                          : NotificationSeverity::Low);
   rocketE.destruct();
@@ -282,6 +283,8 @@ void systemLaunchRocket(flecs::entity planE, LaunchPlan &plan) {
 void systemCreateRocketBuildCategory(flecs::iter &it) {
   auto world = it.world();
   createNotificationCategory(world, "Rocket Build");
+  createNotificationCategory(world, "Rocket Launch");
+  createNotificationCategory(world, "Contracts");
 }
 
 void systemCreateRocketPrefabs(flecs::iter &it) {

--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -257,25 +257,41 @@ void systemLaunchRocket(flecs::entity planE, LaunchPlan &plan) {
             world.lookup("NotificationCategories::Rocket Launch"));
       }
       contract.status = ContractStatus::Closed;
-
-      payload.destruct();
     }
   }
 
   auto launchpadE = planE.target<LaunchingFrom>();
   spdlog::debug("Removing plan: {} launch_date: {} today: {}", planE.id(),
                 plan.launch_date, today);
-  std::string notification =
-      rocket_failure ? std::format("{} failed - {} exploded on launch",
-                                   planE.name().c_str(), rocketE.name().c_str())
-                     : std::format("{} launched {} successfully (${})",
-                                   planE.name().c_str(), rocketE.name().c_str(),
-                                   total_payment);
+
+  std::string notification;
+  if (rocket_failure) {
+    notification = std::format("{} failed - {} exploded on launch",
+                               planE.name().c_str(), rocketE.name().c_str());
+  } else {
+    notification =
+        std::format("{} launched {} successfully (${})", planE.name().c_str(),
+                    rocketE.name().c_str(), total_payment);
+  }
+  notification +=
+      fmt::format("\nOrbit:     {}", plan.target_orbit.name().c_str());
+  notification += fmt::format("\nLaunchpad: {}", launchpadE.name().c_str());
+  notification += fmt::format("\nRocket:    {}%", rocketE.name().c_str());
+  std::string payload_list;
+  for (auto payload : payloads) {
+    payload_list += "\n- " + std::string(payload.name().c_str());
+  }
+  notification += "\nPayloads:" + payload_list;
+
   instantiateBuildingNotification(world, launchpadE, notification);
   instantiateNotification(world, "Launch Complete", notification,
                           world.lookup("NotificationCategories::Rocket Launch"),
                           rocket_failure ? NotificationSeverity::Critical
                                          : NotificationSeverity::High);
+
+  for (auto payload : payloads) {
+    payload.destruct();
+  }
   rocketE.destruct();
   planE.destruct();
 }

--- a/src/modules/site/site.cpp
+++ b/src/modules/site/site.cpp
@@ -2,6 +2,7 @@
 #include "construction_window.h"
 #include "imgui.h"
 #include "modules/base/base.h"
+#include "modules/base/notification.h"
 #include "modules/engine/engine.h"
 #include "modules/engine/gui.h"
 #include "modules/engine/input.h"
@@ -14,6 +15,7 @@
 #include "modules/window/building_detail_window.h"
 #include "rocket_prefab_window.h"
 #include "site_construction.h"
+#include <format>
 #include <spdlog/spdlog.h>
 
 // NOLINTNEXTLINE(modernize-avoid-c-arrays)
@@ -267,7 +269,8 @@ void systemMatchClickToBuilding(flecs::entity e, Transform &t, Sprite &s,
 }
 
 void systemBuildingUpdateManufacuringProgress(
-    flecs::entity e, EffortRequired &effort, const Manufacturing &manufacturing) {
+    flecs::entity e, EffortRequired &effort,
+    const Manufacturing &manufacturing) {
   if (manufacturing.available_effort >= effort.remaining) {
     effort.remaining = 0;
     e.remove<EffortRequired>();
@@ -308,8 +311,11 @@ void systemAutoStartNextBuild(flecs::entity manufacturingE,
   } else if (!manufacturingE.has<AutoBuildBlocked>()) {
     manufacturingE.add<AutoBuildBlocked>();
     instantiateBuildingNotification(world, manufacturingE, result.message);
-    spdlog::debug("Auto-build blocked for manufacturing line {}: {}",
-                  manufacturingE.name().c_str(), result.message);
+    instantiateNotification(
+        world,
+        std::format("Auto-Build Blocked at {}", manufacturingE.name().c_str()),
+        result.message, world.lookup("NotificationCategories::Rocket Build"),
+        NotificationSeverity::Important);
   }
 }
 
@@ -336,7 +342,9 @@ void systemAutoStoreBuiltRocket(flecs::entity rocketE, Rocket &rocket,
   } else if (!lineE.has<AutoStoreBlocked>()) {
     lineE.add<AutoStoreBlocked>();
     instantiateBuildingNotification(world, lineE, result.message);
-    spdlog::debug("Auto-store blocked for rocket {}: {}",
-                  rocketE.name().c_str(), result.message);
+    instantiateNotification(
+        world, std::format("Auto-Store Blocked at {}", lineE.name().c_str()),
+        result.message, world.lookup("NotificationCategories::Rocket Build"),
+        NotificationSeverity::Important);
   }
 }

--- a/src/modules/site/site.cpp
+++ b/src/modules/site/site.cpp
@@ -267,9 +267,10 @@ void systemMatchClickToBuilding(flecs::entity e, Transform &t, Sprite &s,
 }
 
 void systemBuildingUpdateManufacuringProgress(
-    flecs::entity, EffortRequired &effort, const Manufacturing &manufacturing) {
+    flecs::entity e, EffortRequired &effort, const Manufacturing &manufacturing) {
   if (manufacturing.available_effort >= effort.remaining) {
     effort.remaining = 0;
+    e.remove<EffortRequired>();
   } else {
     effort.remaining -= manufacturing.available_effort;
   }

--- a/src/modules/window/main_menu.cpp
+++ b/src/modules/window/main_menu.cpp
@@ -1,6 +1,7 @@
 #include "main_menu.h"
 #include "imgui.h"
 #include "modules/base/base.h"
+#include "notification_window.h"
 #include <flecs.h>
 #include <modules/rocket/active_launches_window.h>
 #include <modules/rocket/contracts_window.h>
@@ -43,6 +44,9 @@ void systemDrawMainMenu(flecs::entity winE, const Simulation sim,
       }
       if (ImGui::MenuItem("Developer Window")) {
         showDeveloperWindow(world);
+      }
+      if (ImGui::MenuItem("Notifications")) {
+        showNotificationWindow(world);
       }
       ImGui::EndMenu();
     }

--- a/src/modules/window/notification_window.cpp
+++ b/src/modules/window/notification_window.cpp
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <flecs.h>
 #include <ranges>
-#include <spdlog/spdlog.h>
 #include <string>
 #include <vector>
 
@@ -100,6 +99,20 @@ bool notificationMatchesFilter(flecs::entity notifE,
   return true;
 }
 
+void markFilteredNotificationsRead(
+    const flecs::query<const Notification> &notif_query,
+    const NotificationWindow &state) {
+  std::vector<flecs::entity> to_mark;
+  notif_query.each([&](flecs::entity notifE, const Notification &) {
+    if (notificationMatchesFilter(notifE, state)) {
+      to_mark.push_back(notifE);
+    }
+  });
+  for (auto &e : to_mark) {
+    e.add<NotificationRead>();
+  }
+}
+
 static void drawFilterRow(NotificationWindow &state,
                           const std::vector<flecs::entity> &categories,
                           const flecs::query<const Notification> &notif_query) {
@@ -148,15 +161,7 @@ static void drawFilterRow(NotificationWindow &state,
 
   ImGui::SameLine();
   if (ImGui::Button("Mark All Read")) {
-    std::vector<flecs::entity> to_mark;
-    notif_query.each([&](flecs::entity notifE, const Notification &) {
-      if (notificationMatchesFilter(notifE, state)) {
-        to_mark.push_back(notifE);
-      }
-    });
-    for (auto &e : to_mark) {
-      e.add<NotificationRead>();
-    }
+    markFilteredNotificationsRead(notif_query, state);
   }
 }
 

--- a/src/modules/window/notification_window.cpp
+++ b/src/modules/window/notification_window.cpp
@@ -153,8 +153,9 @@ void drawNotificationWindow(flecs::entity winE) {
 
   // Sort by entity ID (monotonically increasing = creation order) so that
   // archetype table moves (e.g. adding NotificationRead) don't disturb order.
-  std::ranges::sort(visible,
-                    [](flecs::entity a, flecs::entity b) { return a.id() < b.id(); });
+  std::ranges::sort(visible, [](flecs::entity a, flecs::entity b) {
+    return a.get<Notification>().id < b.get<Notification>().id;
+  });
 
   for (auto notifE : std::ranges::reverse_view(visible)) {
     const auto &notif = notifE.get<Notification>();

--- a/src/modules/window/notification_window.cpp
+++ b/src/modules/window/notification_window.cpp
@@ -1,0 +1,216 @@
+#include "notification_window.h"
+#include "imgui.h"
+#include "modules/engine/gui.h"
+#include <flecs.h>
+#include <spdlog/spdlog.h>
+#include <string>
+#include <vector>
+
+static ImVec4 severityColor(NotificationSeverity sev) {
+  switch (sev) {
+  case NotificationSeverity::Low:
+    return {0.7f, 0.7f, 0.7f, 1.0f};
+  case NotificationSeverity::Medium:
+    return {1.0f, 0.85f, 0.2f, 1.0f};
+  case NotificationSeverity::High:
+    return {1.0f, 0.55f, 0.1f, 1.0f};
+  case NotificationSeverity::Important:
+    return {1.0f, 0.25f, 0.1f, 1.0f};
+  case NotificationSeverity::Critical:
+    return {1.0f, 0.05f, 0.05f, 1.0f};
+  }
+  return {1.0f, 1.0f, 1.0f, 1.0f};
+}
+
+bool notificationMatchesFilter(flecs::entity notifE,
+                                const NotificationWindow &state) {
+  const auto *notif = notifE.try_get<Notification>();
+  if (!notif) {
+    return false;
+  }
+  if (state.severity_filter >= 0 &&
+      notif->severity !=
+          static_cast<NotificationSeverity>(state.severity_filter)) {
+    return false;
+  }
+  if (state.category_filter.is_valid()) {
+    auto cat = notifE.target<NotificationCategory>();
+    if (cat != state.category_filter) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void showNotificationWindow(flecs::world &world) {
+  showWindow(world, "Notifications");
+}
+
+void drawNotificationWindow(flecs::entity winE) {
+  auto &state = winE.get_mut<NotificationWindow>();
+  auto world = winE.world();
+
+  // Guard against stale category filter entity
+  if (state.category_filter.is_valid() && !state.category_filter.is_alive()) {
+    state.category_filter = flecs::entity();
+  }
+
+  auto notif_query = world.query_builder<const Notification>().build();
+
+  // Collect distinct categories from live notifications for the filter combo
+  std::vector<flecs::entity> categories;
+  notif_query.each([&](flecs::entity notifE, const Notification &) {
+    auto cat = notifE.target<NotificationCategory>();
+    if (!cat.is_valid()) {
+      return;
+    }
+    for (const auto &c : categories) {
+      if (c == cat) {
+        return;
+      }
+    }
+    categories.push_back(cat);
+  });
+
+  // --- Severity filter ---
+  const char *sev_label =
+      state.severity_filter < 0
+          ? "All Severities"
+          : to_string(static_cast<NotificationSeverity>(state.severity_filter))
+                .data();
+  ImGui::SetNextItemWidth(150.0f);
+  if (ImGui::BeginCombo("##SevFilter", sev_label)) {
+    if (ImGui::Selectable("All Severities", state.severity_filter < 0)) {
+      state.severity_filter = -1;
+    }
+    for (auto sev : {NotificationSeverity::Low, NotificationSeverity::Medium,
+                     NotificationSeverity::High, NotificationSeverity::Important,
+                     NotificationSeverity::Critical}) {
+      bool sel = state.severity_filter == static_cast<int>(sev);
+      if (ImGui::Selectable(to_string(sev).data(), sel)) {
+        state.severity_filter = static_cast<int>(sev);
+      }
+    }
+    ImGui::EndCombo();
+  }
+
+  ImGui::SameLine();
+
+  // --- Category filter ---
+  const char *cat_label = state.category_filter.is_valid()
+                              ? state.category_filter.name().c_str()
+                              : "All Categories";
+  ImGui::SetNextItemWidth(160.0f);
+  if (ImGui::BeginCombo("##CatFilter", cat_label)) {
+    if (ImGui::Selectable("All Categories",
+                          !state.category_filter.is_valid())) {
+      state.category_filter = flecs::entity();
+    }
+    for (auto &cat : categories) {
+      bool sel = (state.category_filter == cat);
+      if (ImGui::Selectable(cat.name().c_str(), sel)) {
+        state.category_filter = cat;
+      }
+    }
+    ImGui::EndCombo();
+  }
+
+  ImGui::SameLine();
+
+  // --- Mark All Read ---
+  if (ImGui::Button("Mark All Read")) {
+    std::vector<flecs::entity> to_mark;
+    notif_query.each([&](flecs::entity notifE, const Notification &) {
+      if (notificationMatchesFilter(notifE, state)) {
+        to_mark.push_back(notifE);
+      }
+    });
+    for (auto &e : to_mark) {
+      e.add<NotificationRead>();
+    }
+  }
+
+  ImGui::Separator();
+
+  // --- Notification list ---
+  if (!ImGui::BeginChild("NotifList")) {
+    ImGui::EndChild();
+    return;
+  }
+
+  ImDrawList *dl = ImGui::GetWindowDrawList();
+  bool any = false;
+  flecs::entity clicked_notif = flecs::entity::null();
+
+  notif_query.each([&](flecs::entity notifE, const Notification &notif) {
+    if (!notificationMatchesFilter(notifE, state)) {
+      return;
+    }
+    any = true;
+
+    ImGui::PushID(std::to_string(notifE.id()).c_str());
+    float avail_w = ImGui::GetContentRegionAvail().x;
+
+    dl->ChannelsSplit(2);
+    dl->ChannelsSetCurrent(1);
+
+    ImGui::BeginGroup();
+    ImGui::Dummy({0.0f, 2.0f});
+
+    // Header: title + severity badge + category
+    ImGui::TextUnformatted(notif.title.c_str());
+    ImGui::SameLine();
+    ImGui::TextColored(severityColor(notif.severity), "[%s]",
+                       to_string(notif.severity).data());
+    auto cat = notifE.target<NotificationCategory>();
+    if (cat.is_valid()) {
+      ImGui::SameLine();
+      ImGui::Text("| %s", cat.name().c_str());
+    }
+
+    // Body text (wrapped)
+    ImGui::Indent(8.0f);
+    ImGui::PushTextWrapPos(0.0f);
+    ImGui::TextUnformatted(notif.text.c_str());
+    ImGui::PopTextWrapPos();
+    ImGui::Unindent(8.0f);
+
+    ImGui::Dummy({0.0f, 2.0f});
+    ImGui::EndGroup();
+
+    ImVec2 item_min = ImGui::GetItemRectMin();
+    ImVec2 item_max = {item_min.x + avail_w, ImGui::GetItemRectMax().y};
+
+    bool is_unread = !notifE.has<NotificationRead>();
+    bool hovered = ImGui::IsItemHovered();
+
+    // Background drawn behind content via channel 0
+    dl->ChannelsSetCurrent(0);
+    if (is_unread) {
+      dl->AddRectFilled(item_min, item_max, IM_COL32(60, 60, 130, 80), 4.0f);
+    }
+    if (hovered) {
+      dl->AddRect(item_min, item_max, IM_COL32(200, 200, 200, 120), 4.0f);
+    }
+    dl->ChannelsMerge();
+
+    if (ImGui::IsItemClicked()) {
+      clicked_notif = notifE;
+    }
+
+    ImGui::Spacing();
+    ImGui::PopID();
+  });
+
+  // Apply click-to-mark-read after iteration to avoid structural change during each()
+  if (clicked_notif.is_valid() && clicked_notif.is_alive()) {
+    clicked_notif.add<NotificationRead>();
+    spdlog::debug("Notification {} marked as read", clicked_notif.id());
+  }
+
+  if (!any) {
+    ImGui::TextDisabled("No notifications");
+  }
+
+  ImGui::EndChild();
+}

--- a/src/modules/window/notification_window.cpp
+++ b/src/modules/window/notification_window.cpp
@@ -1,27 +1,27 @@
 #include "notification_window.h"
 #include "imgui.h"
 #include "modules/engine/gui.h"
-#include <flecs.h>
 #include <algorithm>
+#include <flecs.h>
 #include <ranges>
 #include <spdlog/spdlog.h>
 #include <string>
 #include <vector>
 
-static ImVec4 severityColor(NotificationSeverity sev) {
+static ImColor severityColor(NotificationSeverity sev) {
   switch (sev) {
   case NotificationSeverity::Low:
-    return {0.7f, 0.7f, 0.7f, 1.0f};
+    return {178, 178, 178};
   case NotificationSeverity::Medium:
-    return {1.0f, 0.85f, 0.2f, 1.0f};
+    return {255, 217, 51};
   case NotificationSeverity::High:
-    return {1.0f, 0.55f, 0.1f, 1.0f};
+    return {255, 140, 26};
   case NotificationSeverity::Important:
-    return {1.0f, 0.25f, 0.1f, 1.0f};
+    return {255, 64, 26};
   case NotificationSeverity::Critical:
-    return {1.0f, 0.05f, 0.05f, 1.0f};
+    return {255, 13, 13};
   }
-  return {1.0f, 1.0f, 1.0f, 1.0f};
+  return {255, 255, 255};
 }
 
 bool notificationMatchesFilter(flecs::entity notifE,
@@ -151,8 +151,6 @@ void drawNotificationWindow(flecs::entity winE) {
     }
   });
 
-  // Sort by entity ID (monotonically increasing = creation order) so that
-  // archetype table moves (e.g. adding NotificationRead) don't disturb order.
   std::ranges::sort(visible, [](flecs::entity a, flecs::entity b) {
     return a.get<Notification>().id < b.get<Notification>().id;
   });

--- a/src/modules/window/notification_window.cpp
+++ b/src/modules/window/notification_window.cpp
@@ -23,7 +23,9 @@ static ImColor severityColor(NotificationSeverity sev) {
   return {255, 255, 255};
 }
 
-static bool drawNotification(flecs::entity notifE, ImDrawList *dl) {
+enum class NotifAction : uint8_t { None, MarkRead, Delete };
+
+static NotifAction drawNotification(flecs::entity notifE, ImDrawList *dl) {
   const auto &notif = notifE.get<Notification>();
 
   ImGui::PushID(std::to_string(notifE.id()).c_str());
@@ -44,6 +46,15 @@ static bool drawNotification(flecs::entity notifE, ImDrawList *dl) {
     ImGui::SameLine();
     ImGui::Text("| %s", cat.name().c_str());
   }
+
+  float button_w =
+      ImGui::CalcTextSize("X").x + ImGui::GetStyle().FramePadding.x * 2;
+  ImGui::SameLine(ImGui::GetContentRegionMax().x - button_w);
+  ImGui::PushStyleColor(ImGuiCol_Button, (ImVec4)ImColor(153, 26, 26));
+  ImGui::PushStyleColor(ImGuiCol_ButtonHovered, (ImVec4)ImColor(217, 51, 51));
+  ImGui::PushStyleColor(ImGuiCol_ButtonActive, (ImVec4)ImColor(255, 77, 77));
+  bool delete_clicked = ImGui::SmallButton("X");
+  ImGui::PopStyleColor(3);
 
   ImGui::Indent(8.0f);
   ImGui::PushTextWrapPos(0.0f);
@@ -73,7 +84,13 @@ static bool drawNotification(flecs::entity notifE, ImDrawList *dl) {
   ImGui::Spacing();
   ImGui::PopID();
 
-  return clicked;
+  if (delete_clicked) {
+    return NotifAction::Delete;
+  }
+  if (clicked) {
+    return NotifAction::MarkRead;
+  }
+  return NotifAction::None;
 }
 
 bool notificationMatchesFilter(flecs::entity notifE,
@@ -203,17 +220,21 @@ void drawNotificationWindow(flecs::entity winE) {
   });
 
   ImDrawList *dl = ImGui::GetWindowDrawList();
-  flecs::entity clicked_notif = flecs::entity::null();
+  flecs::entity acted_notif = flecs::entity::null();
+  NotifAction acted_action = NotifAction::None;
   for (auto notifE : std::ranges::reverse_view(notifications)) {
-    if (drawNotification(notifE, dl)) {
-      clicked_notif = notifE;
+    NotifAction action = drawNotification(notifE, dl);
+    if (action != NotifAction::None) {
+      acted_notif = notifE;
+      acted_action = action;
     }
   }
 
-  // Apply click-to-mark-read after iteration to avoid structural change during
-  // each()
-  if (clicked_notif.is_valid()) {
-    clicked_notif.add<NotificationRead>();
+  // Apply deferred structural change after iteration
+  if (acted_action == NotifAction::MarkRead) {
+    acted_notif.add<NotificationRead>();
+  } else if (acted_action == NotifAction::Delete) {
+    acted_notif.destruct();
   }
 
   if (notifications.empty()) {

--- a/src/modules/window/notification_window.cpp
+++ b/src/modules/window/notification_window.cpp
@@ -24,6 +24,59 @@ static ImColor severityColor(NotificationSeverity sev) {
   return {255, 255, 255};
 }
 
+static bool drawNotification(flecs::entity notifE, ImDrawList *dl) {
+  const auto &notif = notifE.get<Notification>();
+
+  ImGui::PushID(std::to_string(notifE.id()).c_str());
+  float avail_w = ImGui::GetContentRegionAvail().x;
+
+  dl->ChannelsSplit(2);
+  dl->ChannelsSetCurrent(1);
+
+  ImGui::BeginGroup();
+  ImGui::Dummy({0.0f, 2.0f});
+
+  ImGui::TextUnformatted(notif.title.c_str());
+  ImGui::SameLine();
+  ImGui::TextColored(severityColor(notif.severity), "[%s]",
+                     to_string(notif.severity));
+  auto cat = notifE.target<NotificationCategory>();
+  if (cat.is_valid()) {
+    ImGui::SameLine();
+    ImGui::Text("| %s", cat.name().c_str());
+  }
+
+  ImGui::Indent(8.0f);
+  ImGui::PushTextWrapPos(0.0f);
+  ImGui::TextUnformatted(notif.text.c_str());
+  ImGui::PopTextWrapPos();
+  ImGui::Unindent(8.0f);
+
+  ImGui::Dummy({0.0f, 2.0f});
+  ImGui::EndGroup();
+
+  ImVec2 item_min = ImGui::GetItemRectMin();
+  ImVec2 item_max = {item_min.x + avail_w, ImGui::GetItemRectMax().y};
+
+  bool is_unread = !notifE.has<NotificationRead>();
+  bool hovered = ImGui::IsItemHovered();
+  bool clicked = ImGui::IsItemClicked();
+
+  dl->ChannelsSetCurrent(0);
+  if (is_unread) {
+    dl->AddRectFilled(item_min, item_max, IM_COL32(60, 60, 130, 80), 4.0f);
+  }
+  if (hovered) {
+    dl->AddRect(item_min, item_max, IM_COL32(200, 200, 200, 120), 4.0f);
+  }
+  dl->ChannelsMerge();
+
+  ImGui::Spacing();
+  ImGui::PopID();
+
+  return clicked;
+}
+
 bool notificationMatchesFilter(flecs::entity notifE,
                                const NotificationWindow &state) {
   const auto *notif = notifE.try_get<Notification>();
@@ -44,37 +97,9 @@ bool notificationMatchesFilter(flecs::entity notifE,
   return true;
 }
 
-void showNotificationWindow(flecs::world &world) {
-  showWindow(world, "Notifications");
-}
-
-void drawNotificationWindow(flecs::entity winE) {
-  auto &state = winE.get_mut<NotificationWindow>();
-  auto world = winE.world();
-
-  // Guard against stale category filter entity
-  if (state.category_filter.is_valid() && !state.category_filter.is_alive()) {
-    state.category_filter = flecs::entity();
-  }
-
-  auto notif_query = world.query_builder<const Notification>().build();
-
-  // Collect distinct categories from live notifications for the filter combo
-  std::vector<flecs::entity> categories;
-  notif_query.each([&](flecs::entity notifE, const Notification &) {
-    auto cat = notifE.target<NotificationCategory>();
-    if (!cat.is_valid()) {
-      return;
-    }
-    for (const auto &c : categories) {
-      if (c == cat) {
-        return;
-      }
-    }
-    categories.push_back(cat);
-  });
-
-  // --- Severity filter ---
+static void drawFilterRow(NotificationWindow &state,
+                          const std::vector<flecs::entity> &categories,
+                          const flecs::query<const Notification> &notif_query) {
   const char *sev_label =
       state.severity_filter < 0
           ? "All Severities"
@@ -98,7 +123,6 @@ void drawNotificationWindow(flecs::entity winE) {
 
   ImGui::SameLine();
 
-  // --- Category filter ---
   const char *cat_label = state.category_filter.is_valid()
                               ? state.category_filter.name().c_str()
                               : "All Categories";
@@ -119,7 +143,6 @@ void drawNotificationWindow(flecs::entity winE) {
 
   ImGui::SameLine();
 
-  // --- Mark All Read ---
   if (ImGui::Button("Mark All Read")) {
     std::vector<flecs::entity> to_mark;
     notif_query.each([&](flecs::entity notifE, const Notification &) {
@@ -131,6 +154,25 @@ void drawNotificationWindow(flecs::entity winE) {
       e.add<NotificationRead>();
     }
   }
+}
+
+void showNotificationWindow(flecs::world &world) {
+  showWindow(world, "Notifications");
+}
+
+void drawNotificationWindow(flecs::entity winE) {
+  auto &state = winE.get_mut<NotificationWindow>();
+  auto world = winE.world();
+
+  auto notif_query = world.query_builder<const Notification>().build();
+
+  std::vector<flecs::entity> categories;
+  auto cat_node = world.lookup("NotificationCategories");
+  if (cat_node.is_valid()) {
+    cat_node.children([&](flecs::entity e) { categories.push_back(e); });
+  }
+
+  drawFilterRow(state, categories, notif_query);
 
   ImGui::Separator();
 
@@ -140,87 +182,32 @@ void drawNotificationWindow(flecs::entity winE) {
     return;
   }
 
-  ImDrawList *dl = ImGui::GetWindowDrawList();
-  bool any = false;
-  flecs::entity clicked_notif = flecs::entity::null();
-
-  std::vector<flecs::entity> visible;
+  std::vector<flecs::entity> notifications;
   notif_query.each([&](flecs::entity notifE, const Notification &) {
     if (notificationMatchesFilter(notifE, state)) {
-      visible.push_back(notifE);
+      notifications.push_back(notifE);
     }
   });
 
-  std::ranges::sort(visible, [](flecs::entity a, flecs::entity b) {
+  std::ranges::sort(notifications, [](flecs::entity a, flecs::entity b) {
     return a.get<Notification>().id < b.get<Notification>().id;
   });
 
-  for (auto notifE : std::ranges::reverse_view(visible)) {
-    const auto &notif = notifE.get<Notification>();
-    any = true;
-
-    ImGui::PushID(std::to_string(notifE.id()).c_str());
-    float avail_w = ImGui::GetContentRegionAvail().x;
-
-    dl->ChannelsSplit(2);
-    dl->ChannelsSetCurrent(1);
-
-    ImGui::BeginGroup();
-    ImGui::Dummy({0.0f, 2.0f});
-
-    // Header: title + severity badge + category
-    ImGui::TextUnformatted(notif.title.c_str());
-    ImGui::SameLine();
-    ImGui::TextColored(severityColor(notif.severity), "[%s]",
-                       to_string(notif.severity));
-    auto cat = notifE.target<NotificationCategory>();
-    if (cat.is_valid()) {
-      ImGui::SameLine();
-      ImGui::Text("| %s", cat.name().c_str());
-    }
-
-    // Body text (wrapped)
-    ImGui::Indent(8.0f);
-    ImGui::PushTextWrapPos(0.0f);
-    ImGui::TextUnformatted(notif.text.c_str());
-    ImGui::PopTextWrapPos();
-    ImGui::Unindent(8.0f);
-
-    ImGui::Dummy({0.0f, 2.0f});
-    ImGui::EndGroup();
-
-    ImVec2 item_min = ImGui::GetItemRectMin();
-    ImVec2 item_max = {item_min.x + avail_w, ImGui::GetItemRectMax().y};
-
-    bool is_unread = !notifE.has<NotificationRead>();
-    bool hovered = ImGui::IsItemHovered();
-
-    // Background drawn behind content via channel 0
-    dl->ChannelsSetCurrent(0);
-    if (is_unread) {
-      dl->AddRectFilled(item_min, item_max, IM_COL32(60, 60, 130, 80), 4.0f);
-    }
-    if (hovered) {
-      dl->AddRect(item_min, item_max, IM_COL32(200, 200, 200, 120), 4.0f);
-    }
-    dl->ChannelsMerge();
-
-    if (ImGui::IsItemClicked()) {
+  ImDrawList *dl = ImGui::GetWindowDrawList();
+  flecs::entity clicked_notif = flecs::entity::null();
+  for (auto notifE : std::ranges::reverse_view(notifications)) {
+    if (drawNotification(notifE, dl)) {
       clicked_notif = notifE;
     }
-
-    ImGui::Spacing();
-    ImGui::PopID();
   }
 
   // Apply click-to-mark-read after iteration to avoid structural change during
   // each()
-  if (clicked_notif.is_valid() && clicked_notif.is_alive()) {
+  if (clicked_notif.is_valid()) {
     clicked_notif.add<NotificationRead>();
-    spdlog::debug("Notification {} marked as read", clicked_notif.id());
   }
 
-  if (!any) {
+  if (notifications.empty()) {
     ImGui::TextDisabled("No notifications");
   }
 

--- a/src/modules/window/notification_window.cpp
+++ b/src/modules/window/notification_window.cpp
@@ -2,6 +2,8 @@
 #include "imgui.h"
 #include "modules/engine/gui.h"
 #include <flecs.h>
+#include <algorithm>
+#include <ranges>
 #include <spdlog/spdlog.h>
 #include <string>
 #include <vector>
@@ -23,7 +25,7 @@ static ImVec4 severityColor(NotificationSeverity sev) {
 }
 
 bool notificationMatchesFilter(flecs::entity notifE,
-                                const NotificationWindow &state) {
+                               const NotificationWindow &state) {
   const auto *notif = notifE.try_get<Notification>();
   if (!notif) {
     return false;
@@ -76,18 +78,18 @@ void drawNotificationWindow(flecs::entity winE) {
   const char *sev_label =
       state.severity_filter < 0
           ? "All Severities"
-          : to_string(static_cast<NotificationSeverity>(state.severity_filter))
-                .data();
+          : to_string(static_cast<NotificationSeverity>(state.severity_filter));
   ImGui::SetNextItemWidth(150.0f);
   if (ImGui::BeginCombo("##SevFilter", sev_label)) {
     if (ImGui::Selectable("All Severities", state.severity_filter < 0)) {
       state.severity_filter = -1;
     }
-    for (auto sev : {NotificationSeverity::Low, NotificationSeverity::Medium,
-                     NotificationSeverity::High, NotificationSeverity::Important,
-                     NotificationSeverity::Critical}) {
+    for (auto sev :
+         {NotificationSeverity::Low, NotificationSeverity::Medium,
+          NotificationSeverity::High, NotificationSeverity::Important,
+          NotificationSeverity::Critical}) {
       bool sel = state.severity_filter == static_cast<int>(sev);
-      if (ImGui::Selectable(to_string(sev).data(), sel)) {
+      if (ImGui::Selectable(to_string(sev), sel)) {
         state.severity_filter = static_cast<int>(sev);
       }
     }
@@ -142,10 +144,20 @@ void drawNotificationWindow(flecs::entity winE) {
   bool any = false;
   flecs::entity clicked_notif = flecs::entity::null();
 
-  notif_query.each([&](flecs::entity notifE, const Notification &notif) {
-    if (!notificationMatchesFilter(notifE, state)) {
-      return;
+  std::vector<flecs::entity> visible;
+  notif_query.each([&](flecs::entity notifE, const Notification &) {
+    if (notificationMatchesFilter(notifE, state)) {
+      visible.push_back(notifE);
     }
+  });
+
+  // Sort by entity ID (monotonically increasing = creation order) so that
+  // archetype table moves (e.g. adding NotificationRead) don't disturb order.
+  std::ranges::sort(visible,
+                    [](flecs::entity a, flecs::entity b) { return a.id() < b.id(); });
+
+  for (auto notifE : std::ranges::reverse_view(visible)) {
+    const auto &notif = notifE.get<Notification>();
     any = true;
 
     ImGui::PushID(std::to_string(notifE.id()).c_str());
@@ -161,7 +173,7 @@ void drawNotificationWindow(flecs::entity winE) {
     ImGui::TextUnformatted(notif.title.c_str());
     ImGui::SameLine();
     ImGui::TextColored(severityColor(notif.severity), "[%s]",
-                       to_string(notif.severity).data());
+                       to_string(notif.severity));
     auto cat = notifE.target<NotificationCategory>();
     if (cat.is_valid()) {
       ImGui::SameLine();
@@ -200,9 +212,10 @@ void drawNotificationWindow(flecs::entity winE) {
 
     ImGui::Spacing();
     ImGui::PopID();
-  });
+  }
 
-  // Apply click-to-mark-read after iteration to avoid structural change during each()
+  // Apply click-to-mark-read after iteration to avoid structural change during
+  // each()
   if (clicked_notif.is_valid() && clicked_notif.is_alive()) {
     clicked_notif.add<NotificationRead>();
     spdlog::debug("Notification {} marked as read", clicked_notif.id());

--- a/src/modules/window/notification_window.cpp
+++ b/src/modules/window/notification_window.cpp
@@ -94,6 +94,9 @@ bool notificationMatchesFilter(flecs::entity notifE,
       return false;
     }
   }
+  if (state.unread_only && notifE.has<NotificationRead>()) {
+    return false;
+  }
   return true;
 }
 
@@ -122,7 +125,6 @@ static void drawFilterRow(NotificationWindow &state,
   }
 
   ImGui::SameLine();
-
   const char *cat_label = state.category_filter.is_valid()
                               ? state.category_filter.name().c_str()
                               : "All Categories";
@@ -142,7 +144,9 @@ static void drawFilterRow(NotificationWindow &state,
   }
 
   ImGui::SameLine();
+  ImGui::Checkbox("Unread Only", &state.unread_only);
 
+  ImGui::SameLine();
   if (ImGui::Button("Mark All Read")) {
     std::vector<flecs::entity> to_mark;
     notif_query.each([&](flecs::entity notifE, const Notification &) {

--- a/src/modules/window/notification_window.h
+++ b/src/modules/window/notification_window.h
@@ -14,7 +14,7 @@ void drawNotificationWindow(flecs::entity winE);
 
 /// @brief Returns true if the notification passes the active filters.
 bool notificationMatchesFilter(flecs::entity notifE,
-                                const NotificationWindow &state);
+                               const NotificationWindow &state);
 
 /// @brief Adds NotificationRead to every notification that passes the active
 /// filters.

--- a/src/modules/window/notification_window.h
+++ b/src/modules/window/notification_window.h
@@ -6,6 +6,7 @@
 struct NotificationWindow {
   int severity_filter = -1; // -1 = All; otherwise cast to NotificationSeverity
   flecs::entity category_filter = {};
+  bool unread_only = false;
 };
 
 void showNotificationWindow(flecs::world &world);

--- a/src/modules/window/notification_window.h
+++ b/src/modules/window/notification_window.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <flecs.h>
+#include <modules/base/notification.h>
+
+struct NotificationWindow {
+  int severity_filter = -1; // -1 = All; otherwise cast to NotificationSeverity
+  flecs::entity category_filter = {};
+};
+
+void showNotificationWindow(flecs::world &world);
+void drawNotificationWindow(flecs::entity winE);
+
+/// @brief Returns true if the notification passes the active filters.
+bool notificationMatchesFilter(flecs::entity notifE,
+                                const NotificationWindow &state);

--- a/src/modules/window/notification_window.h
+++ b/src/modules/window/notification_window.h
@@ -15,3 +15,9 @@ void drawNotificationWindow(flecs::entity winE);
 /// @brief Returns true if the notification passes the active filters.
 bool notificationMatchesFilter(flecs::entity notifE,
                                 const NotificationWindow &state);
+
+/// @brief Adds NotificationRead to every notification that passes the active
+/// filters.
+void markFilteredNotificationsRead(
+    const flecs::query<const Notification> &notif_query,
+    const NotificationWindow &state);

--- a/src/modules/window/window_module.cpp
+++ b/src/modules/window/window_module.cpp
@@ -52,8 +52,11 @@ void systemToggle(flecs::iter &it, size_t, Simulation &sim,
   }
 }
 
-void systemTickDurationRequired(flecs::entity, DurationRequired &duration) {
+void systemTickDurationRequired(flecs::entity e, DurationRequired &duration) {
   if (duration.remaining > 0) {
     duration.remaining--;
+    if (duration.remaining == 0) {
+      e.remove<DurationRequired>();
+    }
   }
 }

--- a/src/modules/window/window_module.cpp
+++ b/src/modules/window/window_module.cpp
@@ -2,7 +2,9 @@
 #include "SDL_keycode.h"
 #include "main_menu.h"
 #include "modules/base/base.h"
+#include "modules/engine/gui.h"
 #include "modules/engine/input.h"
+#include "notification_window.h"
 #include <flecs.h>
 #include <modules/simulation/simulation.h>
 
@@ -10,9 +12,22 @@ WindowModule::WindowModule(flecs::world &world) {
 
   // Register components
   world.component<MainMenuBar>();
+  world.component<NotificationWindow>()
+      .member("severity_filter", &NotificationWindow::severity_filter)
+      .member("category_filter", &NotificationWindow::category_filter);
 
   // Register window
   world.entity("MainMenuBar").add<MainMenuBar>();
+
+  // Must be registered in OnStart (outside module scope) so the entity is
+  // parented to the root "Windows" node, not the WindowModule entity.
+  world.system("Register Notification Window")
+      .kind(flecs::OnStart)
+      .run([](flecs::iter &it) {
+        auto w = it.world();
+        registerWindow("Notifications", drawNotificationWindow, w)
+            .set<NotificationWindow>({});
+      });
 
   // Register Systems
   world.system<const Simulation, const Game, MainMenuBar>("Draw MainMenu")

--- a/src/modules/window/window_module.cpp
+++ b/src/modules/window/window_module.cpp
@@ -14,7 +14,8 @@ WindowModule::WindowModule(flecs::world &world) {
   world.component<MainMenuBar>();
   world.component<NotificationWindow>()
       .member("severity_filter", &NotificationWindow::severity_filter)
-      .member("category_filter", &NotificationWindow::category_filter);
+      .member("category_filter", &NotificationWindow::category_filter)
+      .member("unread_only", &NotificationWindow::unread_only);
 
   // Register window
   world.entity("MainMenuBar").add<MainMenuBar>();

--- a/src/modules/window/window_module.cpp
+++ b/src/modules/window/window_module.cpp
@@ -55,8 +55,8 @@ void systemToggle(flecs::iter &it, size_t, Simulation &sim,
 void systemTickDurationRequired(flecs::entity e, DurationRequired &duration) {
   if (duration.remaining > 0) {
     duration.remaining--;
-    if (duration.remaining == 0) {
-      e.remove<DurationRequired>();
-    }
+  }
+  if (duration.remaining == 0) {
+    e.remove<DurationRequired>();
   }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(unit_test
   site/rocket_prefab_window/can_afford_rocket_prefab.test.cpp
   stats/stats.test.cpp
   window/building_detail_window.test.cpp
+  window/notification_window.test.cpp
 )
 target_link_libraries(unit_test PRIVATE Catch2::Catch2)
 target_link_libraries(unit_test PRIVATE solcorplib)

--- a/test/base/notification.test.cpp
+++ b/test/base/notification.test.cpp
@@ -48,4 +48,17 @@ SCENARIO("instantiateNotification", "[base][notification]") {
       }
     }
   }
+
+  GIVEN("Multiple notifications are created in sequence") {
+    auto first = instantiateNotification(world, "First", "text");
+    auto second = instantiateNotification(world, "Second", "text");
+    auto third = instantiateNotification(world, "Third", "text");
+
+    WHEN("Their IDs are compared") {
+      THEN("IDs are strictly increasing in creation order") {
+        CHECK(first.get<Notification>().id < second.get<Notification>().id);
+        CHECK(second.get<Notification>().id < third.get<Notification>().id);
+      }
+    }
+  }
 }

--- a/test/rocket/actions/rocket_complete_build_action.test.cpp
+++ b/test/rocket/actions/rocket_complete_build_action.test.cpp
@@ -26,21 +26,6 @@ SCENARIO("RocketCompleteBuildAction", "[action]") {
     }
   }
 
-  GIVEN("A rocket with no EffortRequired") {
-    auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
-    RocketCompleteBuildAction complete{rocket};
-
-    WHEN("Validated") {
-      ValidationResult result = complete.validate(world);
-
-      THEN("The validation fails") {
-        CHECK(!result.ok);
-        CHECK(result.message == "Does not have any effort required");
-      }
-    }
-  }
-
   GIVEN("A rocket that is not under construction") {
     auto rocket = world.entity().add<Rocket>();
     rocket.set<EffortRequired>({.remaining = 0, .total = 300});
@@ -66,7 +51,7 @@ SCENARIO("RocketCompleteBuildAction", "[action]") {
     }
   }
 
-  GIVEN("A rocket under construction with effort still remaining") {
+  GIVEN("A rocket under construction that still has EffortRequired") {
     auto rocket = world.entity().add<Rocket>();
     rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
     rocket.set<EffortRequired>({.remaining = 50, .total = 300});
@@ -95,7 +80,6 @@ SCENARIO("RocketCompleteBuildAction", "[action]") {
   GIVEN("A rocket ready to complete construction") {
     auto rocket = world.entity().add<Rocket>();
     rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
-    rocket.set<EffortRequired>({.remaining = 0, .total = 300});
     rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
     RocketCompleteBuildAction complete{rocket};
 
@@ -122,7 +106,6 @@ SCENARIO("RocketCompleteBuildAction", "[action]") {
       THEN("The rocket transitions to Stored and construction markers are "
            "cleared") {
         CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
-        CHECK(!rocket.has<EffortRequired>());
         CHECK(!rocket.has<RocketTargetState>());
       }
     }
@@ -132,7 +115,6 @@ SCENARIO("RocketCompleteBuildAction", "[action]") {
         "RocketStateTransitionBlocked marker") {
     auto rocket = world.entity().add<Rocket>();
     rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
-    rocket.set<EffortRequired>({.remaining = 0, .total = 300});
     rocket.set<RocketStateTransitionBlocked>({.reason = "stale"});
     RocketCompleteBuildAction complete{rocket};
 

--- a/test/rocket/actions/rocket_complete_move_action.test.cpp
+++ b/test/rocket/actions/rocket_complete_move_action.test.cpp
@@ -63,7 +63,7 @@ SCENARIO("RocketCompleteMoveAction", "[action]") {
     }
   }
 
-  GIVEN("A moving rocket with time remaining") {
+  GIVEN("A moving rocket that still has DurationRequired") {
     auto destination = world.entity();
     auto rocket = world.entity().add<Rocket>();
     rocket.get_mut<Rocket>().state = RocketStateId::Moving;
@@ -79,16 +79,25 @@ SCENARIO("RocketCompleteMoveAction", "[action]") {
         CHECK(result.message == "Rocket has not yet moved to the new location");
       }
     }
+
+    WHEN("block is called") {
+      complete.block(world);
+
+      THEN("RocketStateTransitionBlocked is set with the reason") {
+        REQUIRE(rocket.has<RocketStateTransitionBlocked>());
+        CHECK(rocket.get<RocketStateTransitionBlocked>().reason ==
+              "Rocket has not yet moved to the new location");
+      }
+    }
   }
 
-  GIVEN("A moving rocket with valid target parent and duration") {
+  GIVEN("A moving rocket with valid target parent") {
     auto source = world.entity();
     auto destination = world.entity();
     auto rocket = world.entity().add<Rocket>().child_of(source);
     rocket.get_mut<Rocket>().state = RocketStateId::Moving;
     rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
     rocket.add<RocketTargetParent>(destination);
-    rocket.set<DurationRequired>({.remaining = 0, .total = 5});
     RocketCompleteMoveAction complete{rocket};
 
     WHEN("Validated") {
@@ -116,7 +125,6 @@ SCENARIO("RocketCompleteMoveAction", "[action]") {
         CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
         CHECK(!rocket.has<RocketTargetState>());
         CHECK(!rocket.has<RocketTargetParent>());
-        CHECK(!rocket.has<DurationRequired>());
       }
     }
   }
@@ -128,7 +136,6 @@ SCENARIO("RocketCompleteMoveAction", "[action]") {
     rocket.get_mut<Rocket>().state = RocketStateId::Moving;
     rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
     rocket.add<RocketTargetParent>(destination);
-    rocket.set<DurationRequired>({.remaining = 0, .total = 5});
     rocket.set<RocketStateTransitionBlocked>({.reason = "stale"});
     RocketCompleteMoveAction complete{rocket};
 

--- a/test/rocket/systems.test.cpp
+++ b/test/rocket/systems.test.cpp
@@ -204,35 +204,16 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
   world.import <WindowModule>();
   world.import <RocketModule>();
 
-  GIVEN("A rocket under construction with effort still remaining") {
-    auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
-    rocket.set<EffortRequired>({.remaining = 50, .total = 300});
-    rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
-
-    WHEN("systemRocketCompleteAction is called") {
-      systemRocketCompleteAction(rocket, rocket.get_mut<Rocket>());
-
-      THEN("Nothing happens — construction is still in progress") {
-        CHECK(rocket.get<Rocket>().state == RocketStateId::UnderConstruction);
-        CHECK(rocket.has<EffortRequired>());
-        CHECK(!rocket.has<RocketStateTransitionBlocked>());
-      }
-    }
-  }
-
   GIVEN("A rocket under construction with effort complete") {
     auto rocket = world.entity().add<Rocket>();
     rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
-    rocket.set<EffortRequired>({.remaining = 0, .total = 300});
     rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
 
     WHEN("systemRocketCompleteAction is called") {
       systemRocketCompleteAction(rocket, rocket.get_mut<Rocket>());
 
-      THEN("The rocket transitions to Stored and EffortRequired is removed") {
+      THEN("The rocket transitions to Stored") {
         CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
-        CHECK(!rocket.has<EffortRequired>());
         CHECK(!rocket.has<RocketStateTransitionBlocked>());
       }
     }
@@ -254,27 +235,6 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
     }
   }
 
-  GIVEN("A moving rocket with duration still remaining") {
-    auto source = world.entity();
-    auto destination = world.entity();
-    auto rocket = world.entity().add<Rocket>().child_of(source);
-    rocket.get_mut<Rocket>().state = RocketStateId::Moving;
-    rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
-    rocket.add<RocketTargetParent>(destination);
-    rocket.set<DurationRequired>({.remaining = 3, .total = 5});
-
-    WHEN("systemRocketCompleteAction is called") {
-      systemRocketCompleteAction(rocket, rocket.get_mut<Rocket>());
-
-      THEN("Nothing happens — the move is still in progress") {
-        CHECK(rocket.parent() == source);
-        CHECK(rocket.has<DurationRequired>());
-        CHECK(rocket.get<DurationRequired>().remaining == 3);
-        CHECK(!rocket.has<RocketStateTransitionBlocked>());
-      }
-    }
-  }
-
   GIVEN("A moving rocket with duration complete") {
     auto source = world.entity();
     auto destination = world.entity();
@@ -282,7 +242,6 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
     rocket.get_mut<Rocket>().state = RocketStateId::Moving;
     rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
     rocket.add<RocketTargetParent>(destination);
-    rocket.set<DurationRequired>({.remaining = 0, .total = 5});
 
     WHEN("systemRocketCompleteAction is called") {
       systemRocketCompleteAction(rocket, rocket.get_mut<Rocket>());
@@ -293,7 +252,6 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
         CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
         CHECK(!rocket.has<RocketTargetState>());
         CHECK(!rocket.has<RocketTargetParent>());
-        CHECK(!rocket.has<DurationRequired>());
         CHECK(!rocket.has<RocketStateTransitionBlocked>());
       }
     }

--- a/test/rocket/systems.test.cpp
+++ b/test/rocket/systems.test.cpp
@@ -213,12 +213,10 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
     WHEN("systemRocketCompleteAction is called") {
       systemRocketCompleteAction(rocket, rocket.get_mut<Rocket>());
 
-      THEN("The rocket is blocked and remains under construction") {
+      THEN("Nothing happens — construction is still in progress") {
         CHECK(rocket.get<Rocket>().state == RocketStateId::UnderConstruction);
         CHECK(rocket.has<EffortRequired>());
-        REQUIRE(rocket.has<RocketStateTransitionBlocked>());
-        CHECK(rocket.get<RocketStateTransitionBlocked>().reason ==
-              "Rocket construction is not yet complete");
+        CHECK(!rocket.has<RocketStateTransitionBlocked>());
       }
     }
   }
@@ -268,13 +266,11 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
     WHEN("systemRocketCompleteAction is called") {
       systemRocketCompleteAction(rocket, rocket.get_mut<Rocket>());
 
-      THEN("The rocket is blocked and remains at its current location") {
+      THEN("Nothing happens — the move is still in progress") {
         CHECK(rocket.parent() == source);
         CHECK(rocket.has<DurationRequired>());
         CHECK(rocket.get<DurationRequired>().remaining == 3);
-        REQUIRE(rocket.has<RocketStateTransitionBlocked>());
-        CHECK(rocket.get<RocketStateTransitionBlocked>().reason ==
-              "Rocket has not yet moved to the new location");
+        CHECK(!rocket.has<RocketStateTransitionBlocked>());
       }
     }
   }

--- a/test/site/manufacturing_progress.test.cpp
+++ b/test/site/manufacturing_progress.test.cpp
@@ -43,10 +43,8 @@ SCENARIO("systemBuildingUpdateManufacuringProgress", "[system]") {
     WHEN("manufacturing update is run") {
       auto &effort = rocket.get_mut<EffortRequired>();
       systemBuildingUpdateManufacuringProgress(rocket, effort, manuf);
-      THEN("remaining effort reaches zero but completion is deferred to "
-           "systemRocketCompleteAction") {
-        REQUIRE(rocket.get<EffortRequired>().remaining == 0);
-        REQUIRE(rocket.has<EffortRequired>());
+      THEN("EffortRequired is removed, signalling readiness for completion") {
+        REQUIRE(!rocket.has<EffortRequired>());
         REQUIRE(rocket.get<Rocket>().state == RocketStateId::UnderConstruction);
       }
     }
@@ -57,10 +55,8 @@ SCENARIO("systemBuildingUpdateManufacuringProgress", "[system]") {
     WHEN("manufacturing update is run") {
       auto &effort = rocket.get_mut<EffortRequired>();
       systemBuildingUpdateManufacuringProgress(rocket, effort, manuf);
-      THEN("remaining effort reaches zero but completion is deferred to "
-           "systemRocketCompleteAction") {
-        REQUIRE(rocket.get<EffortRequired>().remaining == 0);
-        REQUIRE(rocket.has<EffortRequired>());
+      THEN("EffortRequired is removed, signalling readiness for completion") {
+        REQUIRE(!rocket.has<EffortRequired>());
         REQUIRE(rocket.get<Rocket>().state == RocketStateId::UnderConstruction);
       }
     }
@@ -71,10 +67,8 @@ SCENARIO("systemBuildingUpdateManufacuringProgress", "[system]") {
     WHEN("manufacturing update is run") {
       auto &effort = rocket.get_mut<EffortRequired>();
       systemBuildingUpdateManufacuringProgress(rocket, effort, manuf);
-      THEN("remaining effort stays zero but completion is deferred to "
-           "systemRocketCompleteAction") {
-        REQUIRE(rocket.get<EffortRequired>().remaining == 0);
-        REQUIRE(rocket.has<EffortRequired>());
+      THEN("EffortRequired is removed, signalling readiness for completion") {
+        REQUIRE(!rocket.has<EffortRequired>());
         REQUIRE(rocket.get<Rocket>().state == RocketStateId::UnderConstruction);
       }
     }

--- a/test/window/notification_window.test.cpp
+++ b/test/window/notification_window.test.cpp
@@ -75,6 +75,49 @@ SCENARIO("notificationMatchesFilter", "[notification_window]") {
     }
   }
 
+  GIVEN("Unread Only filter active") {
+    NotificationWindow state{.unread_only = true};
+
+    WHEN("A notification has not been read") {
+      THEN("It matches") {
+        REQUIRE(notificationMatchesFilter(lowA, state));
+        REQUIRE(notificationMatchesFilter(critB, state));
+      }
+    }
+
+    WHEN("A notification is marked read") {
+      lowA.add<NotificationRead>();
+
+      THEN("The read notification does not match") {
+        REQUIRE(!notificationMatchesFilter(lowA, state));
+      }
+
+      THEN("Unread notifications still match") {
+        REQUIRE(notificationMatchesFilter(highA, state));
+        REQUIRE(notificationMatchesFilter(lowB, state));
+        REQUIRE(notificationMatchesFilter(critB, state));
+      }
+    }
+  }
+
+  GIVEN("Unread Only filter combined with severity filter") {
+    NotificationWindow state{.severity_filter =
+                                 static_cast<int>(NotificationSeverity::Low),
+                             .unread_only = true};
+
+    WHEN("A matching notification is marked read") {
+      lowA.add<NotificationRead>();
+
+      THEN("It no longer matches") {
+        REQUIRE(!notificationMatchesFilter(lowA, state));
+      }
+
+      THEN("Unread Low notifications still match") {
+        REQUIRE(notificationMatchesFilter(lowB, state));
+      }
+    }
+  }
+
   GIVEN("An entity without a Notification component") {
     auto plainEntity = world.entity("Plain");
     NotificationWindow state{};

--- a/test/window/notification_window.test.cpp
+++ b/test/window/notification_window.test.cpp
@@ -6,7 +6,7 @@
 
 SCENARIO("Notification window filtering", "[notification_window]") {
   flecs::world world;
-  world.import<BaseModule>();
+  world.import <BaseModule>();
 
   auto catA = createNotificationCategory(world, "CategoryA");
   auto catB = createNotificationCategory(world, "CategoryB");

--- a/test/window/notification_window.test.cpp
+++ b/test/window/notification_window.test.cpp
@@ -4,31 +4,44 @@
 #include <catch2/catch_test_macros.hpp>
 #include <flecs.h>
 
-SCENARIO("notificationMatchesFilter", "[notification_window]") {
+SCENARIO("Notification window filtering", "[notification_window]") {
   flecs::world world;
   world.import<BaseModule>();
 
   auto catA = createNotificationCategory(world, "CategoryA");
   auto catB = createNotificationCategory(world, "CategoryB");
 
-  auto lowA =
-      instantiateNotification(world, "Low A", "text", catA, NotificationSeverity::Low);
-  auto highA =
-      instantiateNotification(world, "High A", "text", catA, NotificationSeverity::High);
-  auto lowB =
-      instantiateNotification(world, "Low B", "text", catB, NotificationSeverity::Low);
-  auto critB =
-      instantiateNotification(world, "Crit B", "text", catB, NotificationSeverity::Critical);
+  auto lowA = instantiateNotification(world, "Low A", "text", catA,
+                                      NotificationSeverity::Low);
+  auto highA = instantiateNotification(world, "High A", "text", catA,
+                                       NotificationSeverity::High);
+  auto lowB = instantiateNotification(world, "Low B", "text", catB,
+                                      NotificationSeverity::Low);
+  auto critB = instantiateNotification(world, "Crit B", "text", catB,
+                                       NotificationSeverity::Critical);
+
+  auto notif_query = world.query_builder<const Notification>().build();
 
   GIVEN("No filters active") {
     NotificationWindow state{};
 
-    WHEN("Any notification is checked") {
-      THEN("All notifications match") {
+    WHEN("checking if a notification matches") {
+      THEN("all notifications match") {
         REQUIRE(notificationMatchesFilter(lowA, state));
         REQUIRE(notificationMatchesFilter(highA, state));
         REQUIRE(notificationMatchesFilter(lowB, state));
         REQUIRE(notificationMatchesFilter(critB, state));
+      }
+    }
+
+    WHEN("marking all filtered notifications read") {
+      markFilteredNotificationsRead(notif_query, state);
+
+      THEN("all notifications are marked read") {
+        REQUIRE(lowA.has<NotificationRead>());
+        REQUIRE(highA.has<NotificationRead>());
+        REQUIRE(lowB.has<NotificationRead>());
+        REQUIRE(critB.has<NotificationRead>());
       }
     }
   }
@@ -37,12 +50,23 @@ SCENARIO("notificationMatchesFilter", "[notification_window]") {
     NotificationWindow state{.severity_filter =
                                  static_cast<int>(NotificationSeverity::High)};
 
-    WHEN("Notifications are checked") {
-      THEN("Only High severity notifications match") {
+    WHEN("checking if a notification matches") {
+      THEN("only High severity notifications match") {
         REQUIRE(!notificationMatchesFilter(lowA, state));
         REQUIRE(notificationMatchesFilter(highA, state));
         REQUIRE(!notificationMatchesFilter(lowB, state));
         REQUIRE(!notificationMatchesFilter(critB, state));
+      }
+    }
+
+    WHEN("marking all filtered notifications read") {
+      markFilteredNotificationsRead(notif_query, state);
+
+      THEN("only High severity notifications are marked read") {
+        REQUIRE(!lowA.has<NotificationRead>());
+        REQUIRE(highA.has<NotificationRead>());
+        REQUIRE(!lowB.has<NotificationRead>());
+        REQUIRE(!critB.has<NotificationRead>());
       }
     }
   }
@@ -50,12 +74,23 @@ SCENARIO("notificationMatchesFilter", "[notification_window]") {
   GIVEN("Category filter set to CategoryB") {
     NotificationWindow state{.category_filter = catB};
 
-    WHEN("Notifications are checked") {
-      THEN("Only CategoryB notifications match") {
+    WHEN("checking if a notification matches") {
+      THEN("only CategoryB notifications match") {
         REQUIRE(!notificationMatchesFilter(lowA, state));
         REQUIRE(!notificationMatchesFilter(highA, state));
         REQUIRE(notificationMatchesFilter(lowB, state));
         REQUIRE(notificationMatchesFilter(critB, state));
+      }
+    }
+
+    WHEN("marking all filtered notifications read") {
+      markFilteredNotificationsRead(notif_query, state);
+
+      THEN("only CategoryB notifications are marked read") {
+        REQUIRE(!lowA.has<NotificationRead>());
+        REQUIRE(!highA.has<NotificationRead>());
+        REQUIRE(lowB.has<NotificationRead>());
+        REQUIRE(critB.has<NotificationRead>());
       }
     }
   }
@@ -65,8 +100,8 @@ SCENARIO("notificationMatchesFilter", "[notification_window]") {
         .severity_filter = static_cast<int>(NotificationSeverity::Critical),
         .category_filter = catB};
 
-    WHEN("Notifications are checked") {
-      THEN("Only Critical + CategoryB notifications match") {
+    WHEN("checking if a notification matches") {
+      THEN("only Critical + CategoryB notifications match") {
         REQUIRE(!notificationMatchesFilter(lowA, state));
         REQUIRE(!notificationMatchesFilter(highA, state));
         REQUIRE(!notificationMatchesFilter(lowB, state));
@@ -78,24 +113,38 @@ SCENARIO("notificationMatchesFilter", "[notification_window]") {
   GIVEN("Unread Only filter active") {
     NotificationWindow state{.unread_only = true};
 
-    WHEN("A notification has not been read") {
-      THEN("It matches") {
+    WHEN("no notifications have been read") {
+      THEN("all notifications match") {
         REQUIRE(notificationMatchesFilter(lowA, state));
+        REQUIRE(notificationMatchesFilter(highA, state));
+        REQUIRE(notificationMatchesFilter(lowB, state));
         REQUIRE(notificationMatchesFilter(critB, state));
       }
     }
 
-    WHEN("A notification is marked read") {
+    WHEN("a notification is marked read") {
       lowA.add<NotificationRead>();
 
-      THEN("The read notification does not match") {
+      THEN("the read notification does not match") {
         REQUIRE(!notificationMatchesFilter(lowA, state));
       }
 
-      THEN("Unread notifications still match") {
+      THEN("unread notifications still match") {
         REQUIRE(notificationMatchesFilter(highA, state));
         REQUIRE(notificationMatchesFilter(lowB, state));
         REQUIRE(notificationMatchesFilter(critB, state));
+      }
+    }
+
+    WHEN("marking all filtered notifications read") {
+      lowA.add<NotificationRead>();
+      markFilteredNotificationsRead(notif_query, state);
+
+      THEN("unread ones are marked read and already-read ones are unaffected") {
+        REQUIRE(lowA.has<NotificationRead>());
+        REQUIRE(highA.has<NotificationRead>());
+        REQUIRE(lowB.has<NotificationRead>());
+        REQUIRE(critB.has<NotificationRead>());
       }
     }
   }
@@ -105,14 +154,14 @@ SCENARIO("notificationMatchesFilter", "[notification_window]") {
                                  static_cast<int>(NotificationSeverity::Low),
                              .unread_only = true};
 
-    WHEN("A matching notification is marked read") {
+    WHEN("a matching notification is marked read") {
       lowA.add<NotificationRead>();
 
-      THEN("It no longer matches") {
+      THEN("it no longer matches") {
         REQUIRE(!notificationMatchesFilter(lowA, state));
       }
 
-      THEN("Unread Low notifications still match") {
+      THEN("unread Low notifications still match") {
         REQUIRE(notificationMatchesFilter(lowB, state));
       }
     }
@@ -122,8 +171,8 @@ SCENARIO("notificationMatchesFilter", "[notification_window]") {
     auto plainEntity = world.entity("Plain");
     NotificationWindow state{};
 
-    WHEN("It is checked against filters") {
-      THEN("It does not match") {
+    WHEN("checking if it matches") {
+      THEN("it does not match") {
         REQUIRE(!notificationMatchesFilter(plainEntity, state));
       }
     }

--- a/test/window/notification_window.test.cpp
+++ b/test/window/notification_window.test.cpp
@@ -1,0 +1,88 @@
+#include "modules/window/notification_window.h"
+#include "modules/base/base.h"
+#include "modules/base/notification.h"
+#include <catch2/catch_test_macros.hpp>
+#include <flecs.h>
+
+SCENARIO("notificationMatchesFilter", "[notification_window]") {
+  flecs::world world;
+  world.import<BaseModule>();
+
+  auto catA = createNotificationCategory(world, "CategoryA");
+  auto catB = createNotificationCategory(world, "CategoryB");
+
+  auto lowA =
+      instantiateNotification(world, "Low A", "text", catA, NotificationSeverity::Low);
+  auto highA =
+      instantiateNotification(world, "High A", "text", catA, NotificationSeverity::High);
+  auto lowB =
+      instantiateNotification(world, "Low B", "text", catB, NotificationSeverity::Low);
+  auto critB =
+      instantiateNotification(world, "Crit B", "text", catB, NotificationSeverity::Critical);
+
+  GIVEN("No filters active") {
+    NotificationWindow state{};
+
+    WHEN("Any notification is checked") {
+      THEN("All notifications match") {
+        REQUIRE(notificationMatchesFilter(lowA, state));
+        REQUIRE(notificationMatchesFilter(highA, state));
+        REQUIRE(notificationMatchesFilter(lowB, state));
+        REQUIRE(notificationMatchesFilter(critB, state));
+      }
+    }
+  }
+
+  GIVEN("Severity filter set to High") {
+    NotificationWindow state{.severity_filter =
+                                 static_cast<int>(NotificationSeverity::High)};
+
+    WHEN("Notifications are checked") {
+      THEN("Only High severity notifications match") {
+        REQUIRE(!notificationMatchesFilter(lowA, state));
+        REQUIRE(notificationMatchesFilter(highA, state));
+        REQUIRE(!notificationMatchesFilter(lowB, state));
+        REQUIRE(!notificationMatchesFilter(critB, state));
+      }
+    }
+  }
+
+  GIVEN("Category filter set to CategoryB") {
+    NotificationWindow state{.category_filter = catB};
+
+    WHEN("Notifications are checked") {
+      THEN("Only CategoryB notifications match") {
+        REQUIRE(!notificationMatchesFilter(lowA, state));
+        REQUIRE(!notificationMatchesFilter(highA, state));
+        REQUIRE(notificationMatchesFilter(lowB, state));
+        REQUIRE(notificationMatchesFilter(critB, state));
+      }
+    }
+  }
+
+  GIVEN("Both severity Critical and category B filters active") {
+    NotificationWindow state{
+        .severity_filter = static_cast<int>(NotificationSeverity::Critical),
+        .category_filter = catB};
+
+    WHEN("Notifications are checked") {
+      THEN("Only Critical + CategoryB notifications match") {
+        REQUIRE(!notificationMatchesFilter(lowA, state));
+        REQUIRE(!notificationMatchesFilter(highA, state));
+        REQUIRE(!notificationMatchesFilter(lowB, state));
+        REQUIRE(notificationMatchesFilter(critB, state));
+      }
+    }
+  }
+
+  GIVEN("An entity without a Notification component") {
+    auto plainEntity = world.entity("Plain");
+    NotificationWindow state{};
+
+    WHEN("It is checked against filters") {
+      THEN("It does not match") {
+        REQUIRE(!notificationMatchesFilter(plainEntity, state));
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a notification window to see all notifications

- Filterable by category, severity and read status
- Can mark all visible notifications read
- New notifications at the top
- Visually distinguishes severity levels
- Can delete notifications
- More notifications for various good and bad things
- Also refactors the Duration/EffortRequired components to simplify various system logic
- Rocket launch outcome notification is now richer

closes #103 
closes #75 