### PR TITLE
refactor(rocket): Rocket state machine uses entities via relationship instead of enums

### DIFF
--- a/src/modules/rocket/actions.cpp
+++ b/src/modules/rocket/actions.cpp
@@ -21,7 +21,7 @@ ScheduleLaunchAction::validate(const flecs::world &world) const {
   if (!rocket.is_valid()) {
     return ValidationResult::Fail("No rocket selected");
   }
-  if (rocket.get<Rocket>().state != RocketStateId::Stored) {
+  if (!rocket.has<RocketCurrentState>(world.lookup("States::Rocket::Stored"))) {
     return ValidationResult::Fail("Selected rocket is not unassigned");
   }
   if (rocket.has<LaunchingOn>(flecs::Wildcard)) {
@@ -81,7 +81,7 @@ void ScheduleLaunchAction::execute(flecs::world &world) {
   planE.set_name(name.c_str());
   planE.add<LaunchingOn>(rocket);
   planE.add<LaunchingFrom>(launchpad);
-  rocket.get_mut<Rocket>().state = RocketStateId::Assigned;
+  rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Assigned"));
   for (const auto &payload : payloads) {
     if (payload.is_valid()) {
       planE.add<LaunchingWith>(payload);
@@ -105,7 +105,8 @@ ValidationResult EditLaunchAction::validate(const flecs::world &world) const {
     return ValidationResult::Fail("No rocket selected");
   }
   bool same_rocket = (rocket == plan.target<LaunchingOn>());
-  if (!same_rocket && rocket.get<Rocket>().state != RocketStateId::Stored) {
+  if (!same_rocket &&
+      !rocket.has<RocketCurrentState>(world.lookup("States::Rocket::Stored"))) {
     return ValidationResult::Fail("Selected rocket is not unassigned");
   }
   if (!same_rocket && rocket.has<LaunchingOn>(flecs::Wildcard)) {
@@ -167,7 +168,7 @@ void EditLaunchAction::execute(flecs::world &world) {
   planE.set_name(name.c_str());
   planE.add<LaunchingOn>(rocket);
   planE.add<LaunchingFrom>(launchpad);
-  rocket.get_mut<Rocket>().state = RocketStateId::Assigned;
+  rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Assigned"));
   for (const auto &payload : payloads) {
     if (payload.is_valid()) {
       planE.add<LaunchingWith>(payload);
@@ -189,7 +190,7 @@ void CancelLaunchAction::execute(flecs::world &world) {
   }
   auto rocketE = plan.target<LaunchingOn>();
   if (rocketE.is_valid()) {
-    rocketE.get_mut<Rocket>().state = RocketStateId::Stored;
+    rocketE.add<RocketCurrentState>(world.lookup("States::Rocket::Stored"));
   }
   spdlog::debug("Cancelling launch plan: {}", plan.id());
   plan.destruct();
@@ -216,12 +217,14 @@ void RocketBuildAction::execute(flecs::world &world) {
     return;
   }
 
-  auto rocket = world.entity()
-                    .is_a(this->prefab)
-                    .set<RocketTargetState>({.target = RocketStateId::Stored})
-                    .set<EffortRequired>({.remaining = 300, .total = 300})
-                    .child_of(this->line);
-  rocket.ensure<Rocket>().state = RocketStateId::UnderConstruction;
+  auto rocket =
+      world.entity()
+          .is_a(this->prefab)
+          .add<RocketCurrentState>(
+              world.lookup("States::Rocket::UnderConstruction"))
+          .add<RocketTargetState>(world.lookup("States::Rocket::Stored"))
+          .set<EffortRequired>({.remaining = 300, .total = 300})
+          .child_of(this->line);
   rocket.set_name(fmt::format("Rocket {}", Rocket::max_id++).c_str());
 
   // deduct cost
@@ -236,7 +239,8 @@ RocketCompleteBuildAction::validate(const flecs::world &) const {
   if (!rocket.is_valid()) {
     return ValidationResult::Fail("Rocket is not valid");
   }
-  if (rocket.get<Rocket>().state != RocketStateId::UnderConstruction) {
+  if (!rocket.has<RocketCurrentState>(
+          rocket.world().lookup("States::Rocket::UnderConstruction"))) {
     return ValidationResult::Fail("Rocket is not under construction");
   }
   if (rocket.has<EffortRequired>()) {
@@ -251,8 +255,8 @@ void RocketCompleteBuildAction::execute(flecs::world &world) {
     return;
   }
 
-  rocket.get_mut<Rocket>().state = RocketStateId::Stored;
-  rocket.remove<RocketTargetState>();
+  rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Stored"));
+  rocket.remove<RocketTargetState>(flecs::Wildcard);
   rocket.remove<RocketStateTransitionBlocked>();
 
   instantiateNotification(world, "New rocket built",
@@ -286,7 +290,8 @@ ValidationResult RocketMoveAction::validate(const flecs::world &) const {
   if (!rocket.has<Rocket>()) {
     return ValidationResult::Fail("This is not a rocket");
   }
-  if (rocket.get<Rocket>().state != RocketStateId::Stored) {
+  if (!rocket.has<RocketCurrentState>(
+          rocket.world().lookup("States::Rocket::Stored"))) {
     return ValidationResult::Fail(
         "Rocket must be currently stored to be moved");
   }
@@ -308,8 +313,8 @@ void RocketMoveAction::execute(flecs::world &world) {
     return;
   }
   rocket.add<RocketTargetParent>(destination);
-  rocket.get_mut<Rocket>().state = RocketStateId::Moving;
-  rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
+  rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Moving"));
+  rocket.add<RocketTargetState>(world.lookup("States::Rocket::Stored"));
   rocket.set<DurationRequired>({.remaining = days, .total = days});
 }
 
@@ -320,7 +325,8 @@ RocketCompleteMoveAction::validate(const flecs::world &) const {
   if (!rocket.is_valid()) {
     return ValidationResult::Fail("Rocket is not valid");
   }
-  if (rocket.get<Rocket>().state != RocketStateId::Moving) {
+  if (!rocket.has<RocketCurrentState>(
+          rocket.world().lookup("States::Rocket::Moving"))) {
     return ValidationResult::Fail("Rocket is not currently moving");
   }
   if (!rocket.target<RocketTargetParent>().is_valid()) {
@@ -346,8 +352,8 @@ void RocketCompleteMoveAction::execute(flecs::world &world) {
                           NotificationSeverity::Low);
 
   rocket.child_of(targetParent);
-  rocket.get_mut<Rocket>().state = rocket.get<RocketTargetState>().target;
-  rocket.remove<RocketTargetState>();
+  rocket.add<RocketCurrentState>(rocket.target<RocketTargetState>());
+  rocket.remove<RocketTargetState>(flecs::Wildcard);
   rocket.remove<RocketTargetParent>();
   rocket.remove<RocketStateTransitionBlocked>();
 }

--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -307,7 +307,10 @@ void systemCreateRocketPrefabs(flecs::iter &it) {
   }
 
   // Base Rocket Prefab
-  world.prefab("Rocket").child_of(core_node).add<Rocket>();
+  world.prefab("Rocket")
+      .child_of(core_node)
+      .add<Rocket>()
+      .add<RocketCurrentState>(world.lookup("States::Rocket::Stored"));
 }
 
 void systemRocketCompleteAction(flecs::entity e, Rocket &) {

--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -15,6 +15,7 @@
 #include "modules/site/helpers.h"
 #include "spdlog/spdlog.h"
 #include <flecs.h>
+#include <flecs/addons/cpp/c_types.hpp>
 #include <memory>
 #include <modules/simulation/simulation.h>
 #include <vector>
@@ -54,8 +55,7 @@ RocketModule::RocketModule(flecs::world &world) {
       .member("state", &Rocket::state)
       .member("failure_rate", &Rocket::failure_rate)
       .member("cost", &Rocket::cost);
-  world.component<RocketTargetState>().member("target",
-                                              &RocketTargetState::target);
+
   world.component<RocketStateTransitionBlocked>().member(
       "reason", &RocketStateTransitionBlocked::reason);
   world.component<Payload>().member("mass", &Payload::mass);
@@ -90,6 +90,8 @@ RocketModule::RocketModule(flecs::world &world) {
                          // multiple Plans assigned
   world.component<CanLiftTo>().add(flecs::Symmetric);
   world.component<RocketTargetParent>();
+  world.component<RocketCurrentState>().add(flecs::Exclusive);
+  world.component<RocketTargetState>().add(flecs::Exclusive);
 
   // Register Lua bindings
   register_component_lua<LaunchPlan>(
@@ -189,6 +191,14 @@ RocketModule::RocketModule(flecs::world &world) {
       .without<DurationRequired>()
       .kind(UpdatePhase)
       .each(systemRocketCompleteAction);
+
+  auto scope = world.set_scope(0);
+  auto states = world.entity("Rocket").child_of(world.entity("States"));
+  world.entity("Invalid").child_of(states);
+  world.entity("UnderConstruction").child_of(states);
+  world.entity("Stored").child_of(states);
+  world.entity("Moving").child_of(states);
+  world.set_scope(scope);
 }
 
 /// @brief Process LaunchPlans that are due

--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -39,20 +39,7 @@ RocketModule::RocketModule(flecs::world &world) {
       .member("launchDay", &ScheduleLaunchAction::launchDay)
       .member("rocket", &ScheduleLaunchAction::rocket)
       .member("launchpad", &ScheduleLaunchAction::launchpad);
-  world.component<RocketStateId>()
-      .constant("Invalid", RocketStateId::Invalid)
-      .constant("UnderConstruction", RocketStateId::UnderConstruction)
-      .constant("Stored", RocketStateId::Stored)
-      .constant("Moving", RocketStateId::Moving)
-      .constant("Assigned", RocketStateId::Assigned)
-      .constant("IntegratingPayload", RocketStateId::IntegratingPayload)
-      .constant("IntegrationComplete", RocketStateId::IntegrationComplete)
-      .constant("RollingOut", RocketStateId::RollingOut)
-      .constant("OnPad", RocketStateId::OnPad)
-      .constant("Launched", RocketStateId::Launched)
-      .constant("Unavailable", RocketStateId::Unavailable);
   world.component<Rocket>()
-      .member("state", &Rocket::state)
       .member("failure_rate", &Rocket::failure_rate)
       .member("cost", &Rocket::cost);
 
@@ -100,27 +87,14 @@ RocketModule::RocketModule(flecs::world &world) {
       });
   register_component_lua<Rocket>(
       world, "Rocket", [](LuaFieldBuilder<Rocket> &b) {
-        b.field<&Rocket::state>("state")
-            .nested<&Rocket::failure_rate>({"failure_rate"}, {"Stat"})
+        b.nested<&Rocket::failure_rate>({"failure_rate"}, {"Stat"})
             .nested<&Rocket::cost>({"cost"}, {"Stat"});
       });
-  register_enum_table_lua(world, "RocketStateId", [](LuaEnumBuilder &b) {
-    b.value("UnderConstruction", RocketStateId::UnderConstruction)
-        .value("Invalid", RocketStateId::Invalid)
-        .value("Stored", RocketStateId::Stored)
-        .value("Moving", RocketStateId::Moving)
-        .value("Assigned", RocketStateId::Assigned)
-        .value("IntegratingPayload", RocketStateId::IntegratingPayload)
-        .value("IntegrationComplete", RocketStateId::IntegrationComplete)
-        .value("RollingOut", RocketStateId::RollingOut)
-        .value("OnPad", RocketStateId::OnPad)
-        .value("Launched", RocketStateId::Launched)
-        .value("Unavailable", RocketStateId::Unavailable);
-  });
+  register_component_lua<RocketCurrentState>(
+      world, "RocketCurrentState",
+      [](LuaFieldBuilder<RocketCurrentState> &) {});
   register_component_lua<RocketTargetState>(
-      world, "RocketTargetState", [](LuaFieldBuilder<RocketTargetState> &b) {
-        b.field<&RocketTargetState::target>("target");
-      });
+      world, "RocketTargetState", [](LuaFieldBuilder<RocketTargetState> &) {});
   register_component_lua<RocketStateTransitionBlocked>(
       world, "RocketStateTransitionBlocked",
       [](LuaFieldBuilder<RocketStateTransitionBlocked> &b) {
@@ -186,7 +160,7 @@ RocketModule::RocketModule(flecs::world &world) {
   world.system<Rocket>("Rocket Complete State Transition Action")
       .immediate()
       .tick_source(sim.speed)
-      .with<RocketTargetState>()
+      .with<RocketTargetState>(flecs::Wildcard)
       .without<EffortRequired>()
       .without<DurationRequired>()
       .kind(UpdatePhase)
@@ -198,6 +172,7 @@ RocketModule::RocketModule(flecs::world &world) {
   world.entity("UnderConstruction").child_of(states);
   world.entity("Stored").child_of(states);
   world.entity("Moving").child_of(states);
+  world.entity("Assigned").child_of(states);
   world.set_scope(scope);
 }
 
@@ -286,7 +261,7 @@ void systemLaunchRocket(flecs::entity planE, LaunchPlan &plan) {
   notification +=
       fmt::format("\nOrbit:     {}", plan.target_orbit.name().c_str());
   notification += fmt::format("\nLaunchpad: {}", launchpadE.name().c_str());
-  notification += fmt::format("\nRocket:    {}%", rocketE.name().c_str());
+  notification += fmt::format("\nRocket:    {}", rocketE.name().c_str());
   std::string payload_list;
   for (auto payload : payloads) {
     payload_list += "\n- " + std::string(payload.name().c_str());
@@ -335,25 +310,20 @@ void systemCreateRocketPrefabs(flecs::iter &it) {
   world.prefab("Rocket").child_of(core_node).add<Rocket>();
 }
 
-void systemRocketCompleteAction(flecs::entity e, Rocket &rocket) {
+void systemRocketCompleteAction(flecs::entity e, Rocket &) {
   auto world = e.world();
 
   std::unique_ptr<IAction> action;
-
-  switch (rocket.state) {
-  case RocketStateId::UnderConstruction:
+  auto current_state = e.target<RocketCurrentState>();
+  if (current_state == world.lookup("States::Rocket::UnderConstruction")) {
     action = std::make_unique<RocketCompleteBuildAction>(e);
-    break;
-  case RocketStateId::Moving:
+  } else if (current_state == world.lookup("States::Rocket::Moving")) {
     action = std::make_unique<RocketCompleteMoveAction>(e);
-    break;
-  default:
-    break;
   }
 
   if (!action) {
     spdlog::error("No completion action found for rocket {} in state: {}",
-                  e.name().c_str(), static_cast<int>(rocket.state));
+                  e.name().c_str(), current_state.name().c_str());
     return;
   }
   if (action->validate(world)) {

--- a/src/modules/rocket/rocket_module.h
+++ b/src/modules/rocket/rocket_module.h
@@ -47,6 +47,7 @@ struct Rocket {
                     .higher_is_better = false});
 };
 
+struct RocketCurrentState {}; // Relationship
 struct RocketTargetState {
   RocketStateId target;
 };

--- a/src/modules/rocket/rocket_module.h
+++ b/src/modules/rocket/rocket_module.h
@@ -16,24 +16,9 @@ struct LaunchPlan {
       flecs::entity::null(); ///< Target orbit from CanLiftTo
 };
 
-enum class RocketStateId : uint8_t {
-  Invalid = 0,
-  UnderConstruction,
-  Stored,
-  Moving,
-  Assigned,
-  IntegratingPayload,
-  IntegrationComplete,
-  RollingOut,
-  OnPad,
-  Launched,
-  Unavailable
-};
-
 /// @brief Component to indicate entity is a rocket.
 struct Rocket {
   static uint32_t max_id;
-  RocketStateId state = RocketStateId::Stored;
   Stat failure_rate =
       Stat({.id = "failure-rate",
             .display = "Failure Rate",
@@ -47,12 +32,8 @@ struct Rocket {
                     .higher_is_better = false});
 };
 
-struct RocketCurrentState {}; // Relationship
-struct RocketTargetState {
-  RocketStateId target;
-};
-
-// Relationship
+struct RocketCurrentState {};
+struct RocketTargetState {};
 struct RocketTargetParent {};
 
 struct RocketStateTransitionBlocked {

--- a/src/modules/site/site.cpp
+++ b/src/modules/site/site.cpp
@@ -319,12 +319,13 @@ void systemAutoStartNextBuild(flecs::entity manufacturingE,
   }
 }
 
-void systemAutoStoreBuiltRocket(flecs::entity rocketE, Rocket &rocket,
+void systemAutoStoreBuiltRocket(flecs::entity rocketE, Rocket &,
                                 const Manufacturing &manufacturing) {
   if (!manufacturing.auto_store) {
     return;
   }
-  if (rocket.state != RocketStateId::Stored) {
+  if (!rocketE.has<RocketCurrentState>(
+          rocketE.world().lookup("States::Rocket::Stored"))) {
     return;
   }
 

--- a/src/modules/window/building_detail_window.cpp
+++ b/src/modules/window/building_detail_window.cpp
@@ -207,7 +207,8 @@ void drawLaunchpadSection(flecs::entity &entity) {
 
 void drawRocketButtons(flecs::entity &rocket) {
   std::string issue;
-  if (rocket.get<Rocket>().state != RocketStateId::Stored) {
+  if (!rocket.has<RocketCurrentState>(
+          rocket.world().lookup("States::Rocket::Stored"))) {
     issue = "Rocket is not available";
   }
 

--- a/test/rocket/actions/cancel_launch_action.test.cpp
+++ b/test/rocket/actions/cancel_launch_action.test.cpp
@@ -26,7 +26,7 @@ SCENARIO("CancelLaunchAction", "[action]") {
 
   GIVEN("A valid plan with an assigned rocket") {
     auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::Assigned;
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Assigned"));
     auto plan = world.entity("Test Plan").set<LaunchPlan>({});
     plan.add<LaunchingOn>(rocket);
     CancelLaunchAction cancel{plan};
@@ -36,7 +36,8 @@ SCENARIO("CancelLaunchAction", "[action]") {
 
       THEN("The plan is destroyed") { CHECK(!plan.is_alive()); }
       THEN("The rocket is returned to Stored") {
-        CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Stored")));
       }
     }
   }

--- a/test/rocket/actions/edit_launch_action.test.cpp
+++ b/test/rocket/actions/edit_launch_action.test.cpp
@@ -27,7 +27,7 @@ SCENARIO("EditLaunchAction Validation", "[validation][action]") {
   GIVEN("The same name as another plan") {
     world.entity("Other Plan").set<LaunchPlan>({});
     auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::Assigned;
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Assigned"));
     auto launchpad = world.entity().add<Launchpad>();
     auto orbit = world.entity("LEO");
     rocket.set<CanLiftTo>(orbit, {.max_mass = 1000});
@@ -53,7 +53,7 @@ SCENARIO("EditLaunchAction Validation", "[validation][action]") {
 
   GIVEN("The same name as the plan being edited") {
     auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::Assigned;
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Assigned"));
     auto launchpad = world.entity().add<Launchpad>();
     auto orbit = world.entity("LEO");
     rocket.set<CanLiftTo>(orbit, {.max_mass = 1000});
@@ -78,7 +78,7 @@ SCENARIO("EditLaunchAction Validation", "[validation][action]") {
 
   GIVEN("The same rocket already on this plan (Assigned state)") {
     auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::Assigned;
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Assigned"));
     auto launchpad = world.entity().add<Launchpad>();
     auto orbit = world.entity("LEO");
     rocket.set<CanLiftTo>(orbit, {.max_mass = 1000});
@@ -103,9 +103,9 @@ SCENARIO("EditLaunchAction Validation", "[validation][action]") {
 
   GIVEN("A different rocket that is already Assigned") {
     auto oldRocket = world.entity().add<Rocket>();
-    oldRocket.get_mut<Rocket>().state = RocketStateId::Assigned;
+    oldRocket.add<RocketCurrentState>(world.lookup("States::Rocket::Assigned"));
     auto newRocket = world.entity().add<Rocket>();
-    newRocket.get_mut<Rocket>().state = RocketStateId::Assigned;
+    newRocket.add<RocketCurrentState>(world.lookup("States::Rocket::Assigned"));
     auto launchpad = world.entity().add<Launchpad>();
     auto orbit = world.entity("LEO");
     newRocket.set<CanLiftTo>(orbit, {.max_mass = 1000});
@@ -137,7 +137,7 @@ SCENARIO("EditLaunchAction Execution", "[execution][action]") {
 
   GIVEN("An existing plan") {
     auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::Assigned;
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Assigned"));
     auto launchpad = world.entity().add<Launchpad>();
     auto orbit = world.entity("LEO");
     rocket.set<CanLiftTo>(orbit, {.max_mass = 1000});
@@ -164,15 +164,17 @@ SCENARIO("EditLaunchAction Execution", "[execution][action]") {
         CHECK(edit.result.target<LaunchingOn>() == rocket);
       }
       THEN("The rocket remains Assigned") {
-        CHECK(rocket.get<Rocket>().state == RocketStateId::Assigned);
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Assigned")));
       }
     }
   }
 
   GIVEN("An existing plan with a rocket being swapped") {
     auto oldRocket = world.entity().add<Rocket>();
-    oldRocket.get_mut<Rocket>().state = RocketStateId::Assigned;
+    oldRocket.add<RocketCurrentState>(world.lookup("States::Rocket::Assigned"));
     auto newRocket = world.entity().add<Rocket>();
+    newRocket.add<RocketCurrentState>(world.lookup("States::Rocket::Stored"));
     auto launchpad = world.entity().add<Launchpad>();
     auto orbit = world.entity("LEO");
     newRocket.set<CanLiftTo>(orbit, {.max_mass = 1000});
@@ -191,10 +193,12 @@ SCENARIO("EditLaunchAction Execution", "[execution][action]") {
       edit.execute(world);
 
       THEN("The old rocket is returned to Stored") {
-        CHECK(oldRocket.get<Rocket>().state == RocketStateId::Stored);
+        CHECK(oldRocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Stored")));
       }
       THEN("The new rocket is Assigned") {
-        CHECK(newRocket.get<Rocket>().state == RocketStateId::Assigned);
+        CHECK(newRocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Assigned")));
       }
     }
   }

--- a/test/rocket/actions/rocket_build_action.test.cpp
+++ b/test/rocket/actions/rocket_build_action.test.cpp
@@ -84,7 +84,8 @@ SCENARIO("RocketBuildAction", "[action]") {
         });
         CHECK(count == 1);
         REQUIRE(created.is_valid());
-        CHECK(created.get<Rocket>().state == RocketStateId::UnderConstruction);
+        CHECK(created.has<RocketCurrentState>(
+            world.lookup("States::Rocket::UnderConstruction")));
         CHECK(created.has<EffortRequired>());
         CHECK(created.get<EffortRequired>().remaining == 300);
         CHECK(created.get<EffortRequired>().total == 300);

--- a/test/rocket/actions/rocket_complete_build_action.test.cpp
+++ b/test/rocket/actions/rocket_complete_build_action.test.cpp
@@ -53,7 +53,8 @@ SCENARIO("RocketCompleteBuildAction", "[action]") {
 
   GIVEN("A rocket under construction that still has EffortRequired") {
     auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
+    rocket.add<RocketCurrentState>(
+        world.lookup("States::Rocket::UnderConstruction"));
     rocket.set<EffortRequired>({.remaining = 50, .total = 300});
     RocketCompleteBuildAction complete{rocket};
 
@@ -79,8 +80,9 @@ SCENARIO("RocketCompleteBuildAction", "[action]") {
 
   GIVEN("A rocket ready to complete construction") {
     auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
-    rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
+    rocket.add<RocketCurrentState>(
+        world.lookup("States::Rocket::UnderConstruction"));
+    rocket.add<RocketTargetState>(world.lookup("States::Rocket::Stored"));
     RocketCompleteBuildAction complete{rocket};
 
     WHEN("Validated") {
@@ -105,8 +107,9 @@ SCENARIO("RocketCompleteBuildAction", "[action]") {
 
       THEN("The rocket transitions to Stored and construction markers are "
            "cleared") {
-        CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
-        CHECK(!rocket.has<RocketTargetState>());
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Stored")));
+        CHECK(!rocket.has<RocketTargetState>(flecs::Wildcard));
       }
     }
   }
@@ -114,7 +117,8 @@ SCENARIO("RocketCompleteBuildAction", "[action]") {
   GIVEN("A rocket ready to complete construction with a stale "
         "RocketStateTransitionBlocked marker") {
     auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
+    rocket.add<RocketCurrentState>(
+        world.lookup("States::Rocket::UnderConstruction"));
     rocket.set<RocketStateTransitionBlocked>({.reason = "stale"});
     RocketCompleteBuildAction complete{rocket};
 

--- a/test/rocket/actions/rocket_complete_move_action.test.cpp
+++ b/test/rocket/actions/rocket_complete_move_action.test.cpp
@@ -25,7 +25,7 @@ SCENARIO("RocketCompleteMoveAction", "[action]") {
   }
 
   GIVEN("A rocket that is not currently moving") {
-    auto rocket = world.entity().add<Rocket>(); // default state: Stored
+    auto rocket = world.entity().add<Rocket>(); // no RocketCurrentState(Moving)
     RocketCompleteMoveAction complete{rocket};
 
     WHEN("Validated") {
@@ -40,7 +40,7 @@ SCENARIO("RocketCompleteMoveAction", "[action]") {
 
   GIVEN("A moving rocket without a target parent") {
     auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::Moving;
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Moving"));
     RocketCompleteMoveAction complete{rocket};
 
     WHEN("Validated") {
@@ -66,7 +66,7 @@ SCENARIO("RocketCompleteMoveAction", "[action]") {
   GIVEN("A moving rocket that still has DurationRequired") {
     auto destination = world.entity();
     auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::Moving;
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Moving"));
     rocket.add<RocketTargetParent>(destination);
     rocket.set<DurationRequired>({.remaining = 3, .total = 5});
     RocketCompleteMoveAction complete{rocket};
@@ -95,8 +95,8 @@ SCENARIO("RocketCompleteMoveAction", "[action]") {
     auto source = world.entity();
     auto destination = world.entity();
     auto rocket = world.entity().add<Rocket>().child_of(source);
-    rocket.get_mut<Rocket>().state = RocketStateId::Moving;
-    rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Moving"));
+    rocket.add<RocketTargetState>(world.lookup("States::Rocket::Stored"));
     rocket.add<RocketTargetParent>(destination);
     RocketCompleteMoveAction complete{rocket};
 
@@ -122,8 +122,9 @@ SCENARIO("RocketCompleteMoveAction", "[action]") {
 
       THEN("The rocket is reparented and move markers are cleared") {
         CHECK(rocket.parent() == destination);
-        CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
-        CHECK(!rocket.has<RocketTargetState>());
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Stored")));
+        CHECK(!rocket.has<RocketTargetState>(flecs::Wildcard));
         CHECK(!rocket.has<RocketTargetParent>());
       }
     }
@@ -133,8 +134,8 @@ SCENARIO("RocketCompleteMoveAction", "[action]") {
     auto source = world.entity();
     auto destination = world.entity();
     auto rocket = world.entity().add<Rocket>().child_of(source);
-    rocket.get_mut<Rocket>().state = RocketStateId::Moving;
-    rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Moving"));
+    rocket.add<RocketTargetState>(world.lookup("States::Rocket::Stored"));
     rocket.add<RocketTargetParent>(destination);
     rocket.set<RocketStateTransitionBlocked>({.reason = "stale"});
     RocketCompleteMoveAction complete{rocket};

--- a/test/rocket/actions/rocket_move_action.test.cpp
+++ b/test/rocket/actions/rocket_move_action.test.cpp
@@ -29,6 +29,7 @@ SCENARIO("RocketMoveAction", "[action]") {
 
   GIVEN("An invalid Destination") {
     flecs::entity rocket = world.entity().add<Rocket>();
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Stored"));
     flecs::entity destination = flecs::entity::null();
     RocketMoveAction move = RocketMoveAction{RocketEntity{rocket},
                                              DestinationEntity{destination}, 3};
@@ -46,6 +47,7 @@ SCENARIO("RocketMoveAction", "[action]") {
   GIVEN("Destination is the same as current parent") {
     flecs::entity destination = world.entity();
     flecs::entity rocket = world.entity().add<Rocket>().child_of(destination);
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Stored"));
     RocketMoveAction move = RocketMoveAction{RocketEntity{rocket},
                                              DestinationEntity{destination}, 3};
 
@@ -63,7 +65,8 @@ SCENARIO("RocketMoveAction", "[action]") {
   GIVEN("A rocket under construction") {
     flecs::entity destination = world.entity();
     flecs::entity rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
+    rocket.add<RocketCurrentState>(
+        world.lookup("States::Rocket::UnderConstruction"));
     RocketMoveAction move = RocketMoveAction{RocketEntity{rocket},
                                              DestinationEntity{destination}, 3};
 
@@ -81,7 +84,7 @@ SCENARIO("RocketMoveAction", "[action]") {
     flecs::entity source = world.entity();
     flecs::entity destination = world.entity();
     flecs::entity rocket = world.entity().add<Rocket>().child_of(source);
-    rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Stored"));
     RocketMoveAction move = RocketMoveAction{RocketEntity{rocket},
                                              DestinationEntity{destination}, 5};
 
@@ -101,10 +104,11 @@ SCENARIO("RocketMoveAction", "[action]") {
         CHECK(rocket.parent() == source);
       }
       THEN("The move target and duration are recorded") {
-        CHECK(rocket.get<Rocket>().state == RocketStateId::Moving);
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Moving")));
         CHECK(rocket.target<RocketTargetParent>() == destination);
-        REQUIRE(rocket.has<RocketTargetState>());
-        CHECK(rocket.get<RocketTargetState>().target == RocketStateId::Stored);
+        CHECK(rocket.target<RocketTargetState>() ==
+              world.lookup("States::Rocket::Stored"));
         REQUIRE(rocket.has<DurationRequired>());
         CHECK(rocket.get<DurationRequired>().remaining == 5);
         CHECK(rocket.get<DurationRequired>().total == 5);

--- a/test/rocket/actions/schedule_launch_action.test.cpp
+++ b/test/rocket/actions/schedule_launch_action.test.cpp
@@ -26,6 +26,7 @@ SCENARIO("ScheduleLaunchAction Validation", "[validation][action]") {
 
   GIVEN("A rocket in Stored state") {
     auto rocket = world.entity().add<Rocket>();
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Stored"));
     ScheduleLaunchAction launch;
     launch.rocket = rocket;
 
@@ -41,7 +42,7 @@ SCENARIO("ScheduleLaunchAction Validation", "[validation][action]") {
 
   GIVEN("A rocket in Assigned state") {
     auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::Assigned;
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Assigned"));
     ScheduleLaunchAction launch;
     launch.rocket = rocket;
 
@@ -57,7 +58,8 @@ SCENARIO("ScheduleLaunchAction Validation", "[validation][action]") {
 
   GIVEN("A rocket under construction") {
     auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
+    rocket.add<RocketCurrentState>(
+        world.lookup("States::Rocket::UnderConstruction"));
     ScheduleLaunchAction launch;
     launch.rocket = rocket;
 
@@ -73,7 +75,7 @@ SCENARIO("ScheduleLaunchAction Validation", "[validation][action]") {
 
   GIVEN("A rocket already assigned to another plan") {
     auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::Assigned;
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Assigned"));
     rocket.add<LaunchingOn>(world.entity());
     ScheduleLaunchAction launch;
     launch.rocket = rocket;
@@ -90,6 +92,7 @@ SCENARIO("ScheduleLaunchAction Validation", "[validation][action]") {
 
   GIVEN("A missing launchpad") {
     auto rocket = world.entity().add<Rocket>();
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Stored"));
     ScheduleLaunchAction launch;
     launch.rocket = rocket;
 
@@ -127,6 +130,7 @@ SCENARIO("ScheduleLaunchAction Validation", "[validation][action]") {
 
   GIVEN("A valid plan") {
     auto rocket = world.entity().add<Rocket>();
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Stored"));
     auto launchpad = world.entity().add<Launchpad>();
     auto orbit = world.entity("LEO");
     rocket.set<CanLiftTo>(orbit, {.max_mass = 1000});
@@ -159,7 +163,8 @@ SCENARIO("ScheduleLaunchAction Validation", "[validation][action]") {
         CHECK(launch.result.target<LaunchingFrom>() == launchpad);
       }
       THEN("The rocket state is set to Assigned") {
-        CHECK(rocket.get<Rocket>().state == RocketStateId::Assigned);
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Assigned")));
       }
     }
   }

--- a/test/rocket/systems.test.cpp
+++ b/test/rocket/systems.test.cpp
@@ -206,21 +206,24 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
 
   GIVEN("A rocket under construction with effort complete") {
     auto rocket = world.entity().add<Rocket>();
-    rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
-    rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
+    rocket.add<RocketCurrentState>(
+        world.lookup("States::Rocket::UnderConstruction"));
+    rocket.add<RocketTargetState>(world.lookup("States::Rocket::Stored"));
 
     WHEN("systemRocketCompleteAction is called") {
       systemRocketCompleteAction(rocket, rocket.get_mut<Rocket>());
 
       THEN("The rocket transitions to Stored") {
-        CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Stored")));
         CHECK(!rocket.has<RocketStateTransitionBlocked>());
       }
     }
   }
 
   GIVEN("A rocket in Stored state that unexpectedly has EffortRequired") {
-    auto rocket = world.entity().add<Rocket>(); // default state: Stored
+    auto rocket = world.entity().add<Rocket>();
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Stored"));
     rocket.set<EffortRequired>({.remaining = 0, .total = 300});
 
     WHEN("systemRocketCompleteAction is called") {
@@ -228,7 +231,8 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
 
       THEN("Nothing happens — the system ignores states other than "
            "UnderConstruction and Moving") {
-        CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Stored")));
         CHECK(rocket.has<EffortRequired>());
         CHECK(!rocket.has<RocketStateTransitionBlocked>());
       }
@@ -239,8 +243,8 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
     auto source = world.entity();
     auto destination = world.entity();
     auto rocket = world.entity().add<Rocket>().child_of(source);
-    rocket.get_mut<Rocket>().state = RocketStateId::Moving;
-    rocket.set<RocketTargetState>({.target = RocketStateId::Stored});
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Moving"));
+    rocket.add<RocketTargetState>(world.lookup("States::Rocket::Stored"));
     rocket.add<RocketTargetParent>(destination);
 
     WHEN("systemRocketCompleteAction is called") {
@@ -249,8 +253,9 @@ SCENARIO("systemRocketCompleteAction", "[system]") {
       THEN("The rocket is reparented to its destination and move markers are "
            "cleared") {
         CHECK(rocket.parent() == destination);
-        CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
-        CHECK(!rocket.has<RocketTargetState>());
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Stored")));
+        CHECK(!rocket.has<RocketTargetState>(flecs::Wildcard));
         CHECK(!rocket.has<RocketTargetParent>());
         CHECK(!rocket.has<RocketStateTransitionBlocked>());
       }

--- a/test/site/auto_start_next_build.test.cpp
+++ b/test/site/auto_start_next_build.test.cpp
@@ -112,7 +112,8 @@ SCENARIO("systemAutoStartNextBuild", "[system]") {
             created = child;
         });
         REQUIRE(created.is_valid());
-        CHECK(created.get<Rocket>().state == RocketStateId::UnderConstruction);
+        CHECK(created.has<RocketCurrentState>(
+            world.lookup("States::Rocket::UnderConstruction")));
         CHECK(created.has<EffortRequired>());
       }
 

--- a/test/site/auto_store_built_rocket.test.cpp
+++ b/test/site/auto_store_built_rocket.test.cpp
@@ -19,7 +19,7 @@ SCENARIO("systemAutoStoreBuiltRocket", "[system]") {
 
   auto addStoredRocketChild = [&](flecs::entity line) {
     auto rocket = world.entity().add<Rocket>().child_of(line);
-    rocket.get_mut<Rocket>().state = RocketStateId::Stored;
+    rocket.add<RocketCurrentState>(world.lookup("States::Rocket::Stored"));
     return rocket;
   };
 
@@ -37,7 +37,8 @@ SCENARIO("systemAutoStoreBuiltRocket", "[system]") {
       callSystem(rocket, line.get<Manufacturing>());
 
       THEN("the rocket is not moved") {
-        CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Stored")));
         CHECK(rocket.parent() == line);
       }
     }
@@ -49,13 +50,15 @@ SCENARIO("systemAutoStoreBuiltRocket", "[system]") {
     line.add<ManufacturingLineStorage>(storage);
 
     auto rocket = world.entity().add<Rocket>().child_of(line);
-    rocket.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
+    rocket.add<RocketCurrentState>(
+        world.lookup("States::Rocket::UnderConstruction"));
 
     WHEN("systemAutoStoreBuiltRocket runs") {
       callSystem(rocket, line.get<Manufacturing>());
 
       THEN("the rocket is not moved") {
-        CHECK(rocket.get<Rocket>().state == RocketStateId::UnderConstruction);
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::UnderConstruction")));
         CHECK(rocket.parent() == line);
       }
     }
@@ -70,7 +73,8 @@ SCENARIO("systemAutoStoreBuiltRocket", "[system]") {
       callSystem(rocket, line.get<Manufacturing>());
 
       THEN("the rocket is not moved") {
-        CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Stored")));
         CHECK(rocket.parent() == line);
       }
     }
@@ -87,7 +91,8 @@ SCENARIO("systemAutoStoreBuiltRocket", "[system]") {
       callSystem(rocket, line.get<Manufacturing>());
 
       THEN("the rocket transitions to Moving") {
-        CHECK(rocket.get<Rocket>().state == RocketStateId::Moving);
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Moving")));
       }
 
       THEN("AutoStoreBlocked is cleared") {
@@ -112,7 +117,8 @@ SCENARIO("systemAutoStoreBuiltRocket", "[system]") {
       callSystem(rocket, line.get<Manufacturing>());
 
       THEN("the rocket is not moved") {
-        CHECK(rocket.get<Rocket>().state == RocketStateId::Stored);
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Stored")));
         CHECK(rocket.parent() == line);
       }
 
@@ -144,7 +150,8 @@ SCENARIO("systemAutoStoreBuiltRocket", "[system]") {
 
       THEN("the blocked tag is cleared and the rocket begins moving") {
         CHECK(!line.has<AutoStoreBlocked>());
-        CHECK(rocket.get<Rocket>().state == RocketStateId::Moving);
+        CHECK(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::Moving")));
       }
     }
   }

--- a/test/site/manufacturing_progress.test.cpp
+++ b/test/site/manufacturing_progress.test.cpp
@@ -20,9 +20,10 @@ SCENARIO("systemBuildingUpdateManufacuringProgress", "[system]") {
     auto e = world.entity()
                  .add<Rocket>()
                  .set<EffortRequired>({.remaining = remaining, .total = total})
-                 .set<RocketTargetState>({.target = RocketStateId::Stored})
+                 .add<RocketCurrentState>(
+                     world.lookup("States::Rocket::UnderConstruction"))
+                 .add<RocketTargetState>(world.lookup("States::Rocket::Stored"))
                  .child_of(building);
-    e.get_mut<Rocket>().state = RocketStateId::UnderConstruction;
     return e;
   };
 
@@ -45,7 +46,8 @@ SCENARIO("systemBuildingUpdateManufacuringProgress", "[system]") {
       systemBuildingUpdateManufacuringProgress(rocket, effort, manuf);
       THEN("EffortRequired is removed, signalling readiness for completion") {
         REQUIRE(!rocket.has<EffortRequired>());
-        REQUIRE(rocket.get<Rocket>().state == RocketStateId::UnderConstruction);
+        REQUIRE(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::UnderConstruction")));
       }
     }
   }
@@ -57,7 +59,8 @@ SCENARIO("systemBuildingUpdateManufacuringProgress", "[system]") {
       systemBuildingUpdateManufacuringProgress(rocket, effort, manuf);
       THEN("EffortRequired is removed, signalling readiness for completion") {
         REQUIRE(!rocket.has<EffortRequired>());
-        REQUIRE(rocket.get<Rocket>().state == RocketStateId::UnderConstruction);
+        REQUIRE(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::UnderConstruction")));
       }
     }
   }
@@ -69,7 +72,8 @@ SCENARIO("systemBuildingUpdateManufacuringProgress", "[system]") {
       systemBuildingUpdateManufacuringProgress(rocket, effort, manuf);
       THEN("EffortRequired is removed, signalling readiness for completion") {
         REQUIRE(!rocket.has<EffortRequired>());
-        REQUIRE(rocket.get<Rocket>().state == RocketStateId::UnderConstruction);
+        REQUIRE(rocket.has<RocketCurrentState>(
+            world.lookup("States::Rocket::UnderConstruction")));
       }
     }
   }


### PR DESCRIPTION
Pretty much as per title. While it's a bit cumbersome to check whether the `RocketCurrentState` has target of `world.lookup("States::Rocket::Stored")`, it can now be extended for other FSM implementations in the future.

It also means that mods can add new states if they want to.

closes #178