### PR TITLE
feat(rocket): Rocket List & Detail Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,10 +190,15 @@ Use Given/When/Then format for clarity. Test edge cases and failure modes, not j
 
 ### UI Windows
 
+All UI windows and cross-cutting UI components belong in [src/modules/window/](src/modules/window/). This keeps a clean separation of concerns: domain modules (rocket, site, etc.) own ECS data and logic; the window module owns all ImGui rendering. Windows that span multiple domain modules (e.g. a rocket detail window that queries site data) must live in `modules/window/` to avoid circular dependencies between domain modules.
+
+Window component registration (`world.component<MyWindow>()`) and `registerWindow(...)` calls also belong in `window_module.cpp`, not in the domain module.
+
 UI windows follow this pattern:
-1. Define struct with `show()` method in module header
-2. Implement ImGui code in `.cpp` (use `ImGui::Begin/End`, query ECS)
-3. Call from [src/modules/engine/gui.cpp](src/modules/engine/gui.cpp) GUI system
+1. Define state struct and declare `show*` / `draw*` functions in `src/modules/window/mywindow.h`
+2. Implement ImGui code in `src/modules/window/mywindow.cpp` (use `ImGui::Begin/End`, query ECS)
+3. Register the component and window in `src/modules/window/window_module.cpp`
+4. Add both files to the window section of [src/CMakeLists.txt](src/CMakeLists.txt)
 
 ## Configuration
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND SolCorpSources
     modules/window/toolbar.cpp
     modules/window/building_detail_window.cpp
     modules/window/notification_window.cpp
+    modules/window/rocket_detail_window.cpp
     modules/rocket/rocket_module.cpp
     modules/rocket/launch_actions.cpp
     modules/rocket/rocket_actions.cpp
@@ -63,6 +64,7 @@ list(APPEND SolCorpHeaders
     modules/window/toolbar.h
     modules/window/building_detail_window.h
     modules/window/notification_window.h
+    modules/window/rocket_detail_window.h
     modules/rocket/rocket_module.h
     modules/rocket/launch_actions.h
     modules/rocket/rocket_actions.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ list(APPEND SolCorpSources
     modules/window/building_detail_window.cpp
     modules/window/notification_window.cpp
     modules/window/rocket_detail_window.cpp
+    modules/window/rocket_list_window.cpp
     modules/window/storage_picker.cpp
     modules/rocket/rocket_module.cpp
     modules/rocket/launch_actions.cpp
@@ -66,6 +67,7 @@ list(APPEND SolCorpHeaders
     modules/window/building_detail_window.h
     modules/window/notification_window.h
     modules/window/rocket_detail_window.h
+    modules/window/rocket_list_window.h
     modules/window/storage_picker.h
     modules/rocket/rocket_module.h
     modules/rocket/launch_actions.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ list(APPEND SolCorpSources
     modules/window/building_detail_window.cpp
     modules/window/notification_window.cpp
     modules/window/rocket_detail_window.cpp
+    modules/window/storage_picker.cpp
     modules/rocket/rocket_module.cpp
     modules/rocket/launch_actions.cpp
     modules/rocket/rocket_actions.cpp
@@ -65,6 +66,7 @@ list(APPEND SolCorpHeaders
     modules/window/building_detail_window.h
     modules/window/notification_window.h
     modules/window/rocket_detail_window.h
+    modules/window/storage_picker.h
     modules/rocket/rocket_module.h
     modules/rocket/launch_actions.h
     modules/rocket/rocket_actions.h

--- a/src/modules/base/base.cpp
+++ b/src/modules/base/base.cpp
@@ -54,6 +54,7 @@ BaseModule::BaseModule(flecs::world &world) {
   ;
 
   world.component<StateIsTerminal>();
+  world.component<Label>().member("label", &Label::label);
   world.component<EffortRequired>()
       .member("remaining", &EffortRequired::remaining)
       .member("total", &EffortRequired::total);

--- a/src/modules/base/base.h
+++ b/src/modules/base/base.h
@@ -9,6 +9,13 @@
 /// Queries use this to distinguish active from completed/archived records.
 struct StateIsTerminal {};
 
+/// User-visible display name for any entity. Entities without this component
+/// fall back to their ECS name in UI; entities intended as internal/debug only
+/// should omit it.
+struct Label {
+  std::string label;
+};
+
 struct EffortRequired {
   uint32_t remaining = 0;
   uint32_t total = 0;

--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -142,11 +142,13 @@ RocketModule::RocketModule(flecs::world &world) {
   auto scope = world.set_scope(0);
   auto statesRoot = world.entity("States");
   auto rocketStates = world.entity("Rocket").child_of(statesRoot);
-  world.entity("Invalid").child_of(rocketStates);
-  world.entity("UnderConstruction").child_of(rocketStates);
-  world.entity("Stored").child_of(rocketStates);
-  world.entity("Moving").child_of(rocketStates);
-  world.entity("Assigned").child_of(rocketStates);
+  world.entity("Invalid").child_of(rocketStates).add<StateIsTerminal>();
+  world.entity("UnderConstruction")
+      .child_of(rocketStates)
+      .set<Label>({"Under Construction"});
+  world.entity("Stored").child_of(rocketStates).set<Label>({"In Storage"});
+  world.entity("Moving").child_of(rocketStates).set<Label>({"Moving"});
+  world.entity("Assigned").child_of(rocketStates).set<Label>({"Assigned"});
   auto planStates = world.entity("LaunchPlan").child_of(statesRoot);
   auto scheduledState = world.entity("Scheduled").child_of(planStates);
   auto rollingOutState = world.entity("RollingOut").child_of(planStates);

--- a/src/modules/rocket/rocket_module.h
+++ b/src/modules/rocket/rocket_module.h
@@ -32,12 +32,14 @@ struct Rocket {
             .display = "Failure Rate",
             .description = "Likelyhood the rocket will fail on take-off",
             .base = 0.1,
-            .higher_is_better = false});
+            .higher_is_better = false,
+            .format = Stat::Format::Percentage});
   Stat cost = Stat({.id = "cost",
                     .display = "Cost",
                     .description = "Cost to build this rocket",
                     .base = 5'000'000,
-                    .higher_is_better = false});
+                    .higher_is_better = false,
+                    .format = Stat::Format::Currency});
   Stat rollout_days = Stat(
       {.id = "rollout-days",
        .display = "Rollout Duration",

--- a/src/modules/site/rocket_prefab_window.cpp
+++ b/src/modules/site/rocket_prefab_window.cpp
@@ -112,8 +112,7 @@ void drawRocketPrefabWindow(flecs::entity winE) {
 
     ImGui::Text("%s", prefabE.name().c_str());
     ImGui::TextDisabled("Low Earth Orbit: %s kg", maxMassText.c_str());
-    Widgets::StatTooltip(&cost,
-                         [](double v) { return "$" + format_locale(v); });
+    Widgets::StatTooltip(&cost);
 
     RocketBuildAction action{PrefabEntity{prefabE}, LineEntity{manufacturingE},
                              rocketCost};

--- a/src/modules/stats/stats.cpp
+++ b/src/modules/stats/stats.cpp
@@ -1,5 +1,7 @@
 #include "stats.h"
+#include "modules/engine/helpers.h"
 #include "modules/lua/lua.h"
+#include <format>
 #include <modules/base/base.h>
 
 void systemInitialiseStats(flecs::iter &iter);
@@ -67,6 +69,18 @@ const std::string &Stat::display() const { return m_display; }
 const std::string &Stat::description() const { return m_description; }
 const std::vector<EffectModifier> &Stat::modifiers() const {
   return m_modifiers;
+}
+
+std::string Stat::format(double value) const {
+  switch (m_format) {
+  case Format::Currency:
+    return "$" + format_locale(value);
+  case Format::Percentage:
+    return std::format("{:.0f}%", value * 100);
+  case Format::Number:
+  default:
+    return std::format("{:.0f}", value);
+  }
 }
 
 bool Stat::addModifier(const Modifier &modifier,

--- a/src/modules/stats/stats.h
+++ b/src/modules/stats/stats.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <flecs.h>
 #include <string>
 #include <vector>
@@ -28,15 +29,23 @@ struct StatInit {
   std::string description;
   double base = 0.0;
   bool higher_is_better = true;
+  enum class Format : std::uint8_t {
+    Number,
+    Currency,
+    Percentage
+  } format = Format::Number;
 };
 
 /// Represents a modifiable stat.
 class Stat {
 public:
+  using Format = StatInit::Format;
+
   Stat() = default;
   explicit Stat(const StatInit &init)
       : m_id(init.id), m_display(init.display), m_description(init.description),
-        m_base(init.base), higher_is_better(init.higher_is_better) {}
+        m_base(init.base), higher_is_better(init.higher_is_better),
+        m_format(init.format) {}
 
   /// Gets the base value of the stat.
   /// @return The base value.
@@ -73,6 +82,9 @@ public:
   /// @return The list of modifiers.
   [[nodiscard]] const std::vector<EffectModifier> &modifiers() const;
 
+  /// Formats a value according to this stat's display type.
+  [[nodiscard]] std::string format(double value) const;
+
   /// @brief Checks if higher values of the stat are better.
   /// @return True if higher values are better, false otherwise.
   [[nodiscard]] bool isHigherBetter() const { return higher_is_better; }
@@ -87,6 +99,7 @@ public:
   double m_multiplicative_modifiers =
       1.0f;                     ///< The total multiplicative modifiers.
   bool higher_is_better = true; ///< Indicates if higher values are better.
+  Format m_format = Format::Number;
 };
 
 /// Applies modifiers to the stats of an entity.

--- a/src/modules/window/building_detail_window.cpp
+++ b/src/modules/window/building_detail_window.cpp
@@ -5,10 +5,10 @@
 #include "modules/engine/gui.h"
 #include "modules/rocket/launch_detail_window.h"
 #include "modules/rocket/launch_window.h"
-#include "modules/rocket/rocket_actions.h"
 #include "modules/rocket/rocket_module.h"
 #include "modules/site/rocket_prefab_window.h"
 #include "modules/site/site.h"
+#include "rocket_detail_window.h"
 #include "spdlog/fmt/bundled/core.h"
 #include "spdlog/spdlog.h"
 #include "widgets/stat_widget.h"
@@ -21,10 +21,6 @@
 void drawManufacturingSection(flecs::entity &entity);
 void drawStorageSection(flecs::entity &entity);
 void drawLaunchpadSection(flecs::entity &entity);
-void drawRocketButtons(flecs::entity &rocket);
-void storagePickerPopup(const char *popupId, bool open, flecs::world &world,
-                        flecs::entity excluded,
-                        const std::function<void(flecs::entity)> &onConfirm);
 
 void showBuildingDetailWindow(const flecs::entity &entity) {
   spdlog::debug("Showing BuildingDetailWindow");
@@ -101,9 +97,11 @@ void drawManufacturingSection(flecs::entity &entity) {
   if (e.is_valid()) {
     // There is a rocket on the line
     ImGui::Text("Constructing %s", e.name().c_str());
-
+    ImGui::SameLine();
+    if (ImGui::SmallButton("View")) {
+      showRocketDetailWindow(e);
+    }
     ImGui::ProgressBar(getEntityEffortRequired(e));
-    drawRocketButtons(e);
 
   } else {
     // Nothing yet - the line is empty
@@ -172,7 +170,10 @@ void drawStorageSection(flecs::entity &entity) {
                 plan.is_valid()
                     ? fmt::format("({})", plan.name().c_str()).c_str()
                     : "");
-    drawRocketButtons(rocket);
+    ImGui::SameLine();
+    if (ImGui::SmallButton("View")) {
+      showRocketDetailWindow(rocket);
+    }
     ImGui::Separator();
     ImGui::PopID();
   });
@@ -202,47 +203,6 @@ void drawLaunchpadSection(flecs::entity &entity) {
   ImGui::Separator();
   if (ImGui::Button("Schedule Launch")) {
     showLaunchWindowAdd(world, nullptr, &entity);
-  }
-}
-
-void drawRocketButtons(flecs::entity &rocket) {
-  std::string issue;
-  if (!rocket.has<RocketCurrentState>(
-          rocket.world().lookup("States::Rocket::Stored"))) {
-    issue = "Rocket is not available";
-  }
-
-  bool openPopup = Widgets::ActionButton(
-      ButtonLabel{.text = "Move"},
-      ButtonTooltip{.text = "Move the rocket to another storage at this site"},
-      issue);
-  ImGui::SameLine();
-
-  auto target = rocket.target<LaunchingOn>();
-  std::string tooltip =
-      target.is_valid() ? "View launch plan" : "Schedule the rocket for launch";
-  if (Widgets::ActionButton(
-          ButtonLabel{.text = target.is_valid() ? "View Plan" : "Schedule"},
-          ButtonTooltip{.text = tooltip.c_str()}, issue)) {
-    if (target.is_valid()) {
-      showLaunchDetailWindow(target);
-    } else {
-      showLaunchWindowAdd(rocket.world(), &rocket, nullptr);
-    }
-  }
-  auto world = rocket.world();
-  auto currentStorage = rocket.parent();
-  auto site = findAncestorWith<Site>(currentStorage);
-  if (site.is_valid()) {
-    auto moveDurationDays =
-        static_cast<uint8_t>(rocket.get<Rocket>().move_days.value());
-    storagePickerPopup("Move Rocket", openPopup, world, currentStorage,
-                       [&](flecs::entity dest) {
-                         RocketMoveAction action{RocketEntity{rocket},
-                                                 DestinationEntity{dest},
-                                                 moveDurationDays};
-                         action.execute(world);
-                       });
   }
 }
 

--- a/src/modules/window/building_detail_window.cpp
+++ b/src/modules/window/building_detail_window.cpp
@@ -11,6 +11,7 @@
 #include "rocket_detail_window.h"
 #include "spdlog/fmt/bundled/core.h"
 #include "spdlog/spdlog.h"
+#include "storage_picker.h"
 #include "widgets/stat_widget.h"
 #include "widgets/widgets.h"
 #include <flecs.h>
@@ -204,56 +205,6 @@ void drawLaunchpadSection(flecs::entity &entity) {
   if (ImGui::Button("Schedule Launch")) {
     showLaunchWindowAdd(world, nullptr, &entity);
   }
-}
-
-void storagePickerPopup(const char *popupId, bool open, flecs::world &world,
-                        flecs::entity excluded,
-                        const std::function<void(flecs::entity)> &onConfirm) {
-  static flecs::entity destination;
-  static std::string display = "<Select one>";
-  if (open) {
-    destination = flecs::entity();
-    display = "<Select one>";
-    ImGui::OpenPopup(popupId);
-  }
-  if (!ImGui::BeginPopupModal(popupId)) {
-    return;
-  }
-  ImGui::Text("Where to?");
-  ImGui::SameLine();
-
-  auto storageFacilities =
-      world.query_builder().with<Storage>().with<Site>().up().build();
-
-  if (ImGui::BeginCombo("##StorageCombo", display.c_str())) {
-    storageFacilities.each([&](flecs::entity s) {
-      ImGui::BeginDisabled(excluded.is_valid() && s == excluded);
-      if (ImGui::Selectable(s.parent().name().c_str(), destination == s)) {
-        destination = s;
-        display = s.parent().name();
-      }
-      ImGui::EndDisabled();
-    });
-    ImGui::EndCombo();
-  }
-  ImGui::Separator();
-  if (ImGui::Button("Cancel")) {
-    ImGui::CloseCurrentPopup();
-  }
-  ImGui::SameLine();
-  std::string issue;
-  if (!destination.is_valid()) {
-    issue = "Select a destination";
-  } else if (destination == excluded) {
-    issue = "Already here";
-  }
-  if (Widgets::ActionButton(ButtonLabel{.text = "Ok"},
-                            ButtonTooltip{.text = "Confirm selection"},
-                            issue)) {
-    onConfirm(destination);
-    ImGui::CloseCurrentPopup();
-  }
-  ImGui::EndPopup();
 }
 
 float getEntityEffortRequired(flecs::entity &entity) {

--- a/src/modules/window/building_detail_window.h
+++ b/src/modules/window/building_detail_window.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <flecs.h>
-#include <functional>
 
 struct BuildingDetailWindow {
   flecs::entity buildingE;
@@ -9,10 +8,6 @@ struct BuildingDetailWindow {
 
 void showBuildingDetailWindow(const flecs::entity &buildingE);
 void drawBuildingDetailWindow(flecs::entity winE);
-
-void storagePickerPopup(const char *popupId, bool open, flecs::world &world,
-                        flecs::entity excluded,
-                        const std::function<void(flecs::entity)> &onConfirm);
 
 /// @brief Gets the progress of the current effort on an entity, if it has one
 /// @param[in] entity The entity to check for an EffortRequired component

--- a/src/modules/window/building_detail_window.h
+++ b/src/modules/window/building_detail_window.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <flecs.h>
+#include <functional>
 
 struct BuildingDetailWindow {
   flecs::entity buildingE;
@@ -8,6 +9,10 @@ struct BuildingDetailWindow {
 
 void showBuildingDetailWindow(const flecs::entity &buildingE);
 void drawBuildingDetailWindow(flecs::entity winE);
+
+void storagePickerPopup(const char *popupId, bool open, flecs::world &world,
+                        flecs::entity excluded,
+                        const std::function<void(flecs::entity)> &onConfirm);
 
 /// @brief Gets the progress of the current effort on an entity, if it has one
 /// @param[in] entity The entity to check for an EffortRequired component

--- a/src/modules/window/rocket_detail_window.cpp
+++ b/src/modules/window/rocket_detail_window.cpp
@@ -32,7 +32,10 @@ void drawRocketDetailWindow(flecs::entity winE) {
 
   auto &rocketData = state.rocket.get<Rocket>();
   auto stateE = state.rocket.target<RocketCurrentState>();
-  const char *stateName = stateE.is_valid() ? stateE.name().c_str() : "Unknown";
+  const char *stateName =
+      stateE.is_valid() && stateE.has<Label>()
+          ? stateE.get<Label>().label.c_str()
+          : (stateE.is_valid() ? stateE.name().c_str() : "Unknown");
 
   std::string actionIssue;
   if (!state.rocket.has<RocketCurrentState>(

--- a/src/modules/window/rocket_detail_window.cpp
+++ b/src/modules/window/rocket_detail_window.cpp
@@ -1,0 +1,182 @@
+#include "rocket_detail_window.h"
+#include "building_detail_window.h"
+#include "imgui.h"
+#include "modules/base/base.h"
+#include "modules/engine/gui.h"
+#include "modules/engine/helpers.h"
+#include "modules/rocket/launch_detail_window.h"
+#include "modules/rocket/launch_window.h"
+#include "modules/rocket/rocket_actions.h"
+#include "modules/rocket/rocket_module.h"
+#include "modules/site/site.h"
+#include "widgets/stat_widget.h"
+#include "widgets/widgets.h"
+#include <flecs.h>
+#include <functional>
+
+void showRocketDetailWindow(flecs::entity rocketE) {
+  auto world = rocketE.world();
+  auto win = showWindow(world, "Rocket Detail");
+  win.get_mut<RocketDetailWindow>().rocket = rocketE;
+}
+
+void drawRocketDetailWindow(flecs::entity winE) {
+  auto &state = winE.get_mut<RocketDetailWindow>();
+  auto world = winE.world();
+
+  if (!state.rocket.is_valid() || !state.rocket.is_alive()) {
+    hideWindow(world, "Rocket Detail");
+    return;
+  }
+
+  auto &rocketData = state.rocket.get<Rocket>();
+  auto stateE = state.rocket.target<RocketCurrentState>();
+  const char *stateName = stateE.is_valid() ? stateE.name().c_str() : "Unknown";
+
+  ImGui::Text("%s", state.rocket.name().c_str());
+  ImGui::SameLine();
+  ImGui::TextDisabled("(%s)", stateName);
+  ImGui::Separator();
+
+  if (ImGui::BeginTable("##rocketDetailLayout", 2,
+                        ImGuiTableFlags_SizingStretchProp)) {
+    ImGui::TableSetupColumn("##info", ImGuiTableColumnFlags_WidthStretch,
+                            0.55f);
+    ImGui::TableSetupColumn("##stats", ImGuiTableColumnFlags_WidthStretch,
+                            0.45f);
+    ImGui::TableNextRow();
+
+    ImGui::TableSetColumnIndex(0);
+
+    auto prefabE = state.rocket.target(flecs::IsA);
+    ImGui::TextDisabled("Model");
+    ImGui::TextUnformatted(prefabE.is_valid() ? prefabE.name().c_str() : "-");
+    ImGui::Spacing();
+
+    auto facilityE = state.rocket.parent();
+    auto buildingE =
+        facilityE.is_valid() ? facilityE.parent() : flecs::entity();
+    ImGui::TextDisabled("Location");
+    if (buildingE.is_valid() && buildingE.has<Building>()) {
+      ImGui::Text("%s", buildingE.name().c_str());
+      ImGui::SameLine();
+      if (ImGui::SmallButton("View##building")) {
+        showBuildingDetailWindow(buildingE);
+      }
+    } else if (facilityE.is_valid()) {
+      ImGui::TextUnformatted(facilityE.name().c_str());
+    } else {
+      ImGui::TextUnformatted("-");
+    }
+    ImGui::Spacing();
+
+    auto planE = state.rocket.target<LaunchingOn>();
+    ImGui::TextDisabled("Plan");
+    if (planE.is_valid()) {
+      ImGui::Text("%s", planE.name().c_str());
+      ImGui::SameLine();
+      if (ImGui::SmallButton("View##plan")) {
+        showLaunchDetailWindow(planE);
+      }
+    } else {
+      ImGui::TextUnformatted("None");
+    }
+    ImGui::Spacing();
+
+    if (ImGui::BeginTable(
+            "##liftCapacity", 2,
+            ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersInnerH |
+                ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingStretchProp)) {
+      ImGui::TableSetupColumn("Orbit");
+      ImGui::TableSetupColumn("Max Payload", ImGuiTableColumnFlags_WidthFixed,
+                              90.0f);
+      ImGui::TableHeadersRow();
+
+      bool anyOrbits = false;
+      state.rocket.each<CanLiftTo>([&](flecs::entity orbit) {
+        if (!orbit.is_valid()) {
+          return;
+        }
+        auto &liftTo = state.rocket.get<CanLiftTo>(orbit);
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::TextUnformatted(orbit.name().c_str());
+        ImGui::TableSetColumnIndex(1);
+        ImGui::Text(
+            "%s kg",
+            format_locale(static_cast<int64_t>(liftTo.max_mass)).c_str());
+        anyOrbits = true;
+      });
+
+      if (!anyOrbits) {
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::TextDisabled("None");
+      }
+
+      ImGui::EndTable();
+    }
+
+    ImGui::TableSetColumnIndex(1);
+
+    ImGui::TextDisabled("Stats");
+    Widgets::StatTooltip(&rocketData.failure_rate);
+    Widgets::StatTooltip(&rocketData.cost,
+                         [](double v) { return "$" + format_locale(v); });
+    Widgets::StatTooltip(&rocketData.rollout_days);
+    Widgets::StatTooltip(&rocketData.move_days);
+
+    ImGui::EndTable();
+  }
+
+  ImGui::Spacing();
+  ImGui::Separator();
+
+  drawRocketButtons(state.rocket);
+  ImGui::SameLine();
+  if (ImGui::Button("Close")) {
+    hideWindow(world, "Rocket Detail");
+    state.rocket = flecs::entity::null();
+  }
+}
+
+void drawRocketButtons(flecs::entity &rocket) {
+  std::string issue;
+  if (!rocket.has<RocketCurrentState>(
+          rocket.world().lookup("States::Rocket::Stored"))) {
+    issue = "Rocket is not available";
+  }
+
+  bool openPopup = Widgets::ActionButton(
+      ButtonLabel{.text = "Move"},
+      ButtonTooltip{.text = "Move the rocket to another storage at this site"},
+      issue);
+  ImGui::SameLine();
+
+  auto target = rocket.target<LaunchingOn>();
+  std::string tooltip =
+      target.is_valid() ? "View launch plan" : "Schedule the rocket for launch";
+  if (Widgets::ActionButton(
+          ButtonLabel{.text = target.is_valid() ? "View Plan" : "Schedule"},
+          ButtonTooltip{.text = tooltip.c_str()}, issue)) {
+    if (target.is_valid()) {
+      showLaunchDetailWindow(target);
+    } else {
+      showLaunchWindowAdd(rocket.world(), &rocket, nullptr);
+    }
+  }
+  auto world = rocket.world();
+  auto currentStorage = rocket.parent();
+  auto site = findAncestorWith<Site>(currentStorage);
+  if (site.is_valid()) {
+    auto moveDurationDays =
+        static_cast<uint8_t>(rocket.get<Rocket>().move_days.value());
+    storagePickerPopup("Move Rocket", openPopup, world, currentStorage,
+                       [&](flecs::entity dest) {
+                         RocketMoveAction action{RocketEntity{rocket},
+                                                 DestinationEntity{dest},
+                                                 moveDurationDays};
+                         action.execute(world);
+                       });
+  }
+}

--- a/src/modules/window/rocket_detail_window.cpp
+++ b/src/modules/window/rocket_detail_window.cpp
@@ -48,6 +48,16 @@ void drawRocketDetailWindow(flecs::entity winE) {
   ImGui::Text("%s", state.rocket.name().c_str());
   ImGui::SameLine();
   ImGui::TextDisabled("(%s)", stateName);
+  if (state.rocket.has<RocketStateTransitionBlocked>()) {
+    const auto &blocked = state.rocket.get<RocketStateTransitionBlocked>();
+    ImGui::SameLine();
+    ImGui::TextColored((ImVec4)ImColor::HSV(0.13f, 1.0f, 1.0f),
+                       "\xef\x81\xb1"); // fa-triangle-exclamation f071
+    if (ImGui::BeginItemTooltip()) {
+      ImGui::Text("%s", blocked.reason.c_str());
+      ImGui::EndTooltip();
+    }
+  }
   ImGui::Separator();
 
   if (ImGui::BeginTable("##rocketDetailLayout", 2,

--- a/src/modules/window/rocket_detail_window.cpp
+++ b/src/modules/window/rocket_detail_window.cpp
@@ -33,6 +33,14 @@ void drawRocketDetailWindow(flecs::entity winE) {
   auto stateE = state.rocket.target<RocketCurrentState>();
   const char *stateName = stateE.is_valid() ? stateE.name().c_str() : "Unknown";
 
+  std::string actionIssue;
+  if (!state.rocket.has<RocketCurrentState>(
+          world.lookup("States::Rocket::Stored"))) {
+    actionIssue = "Rocket is not available";
+  }
+
+  bool openMovePopup = false;
+
   ImGui::Text("%s", state.rocket.name().c_str());
   ImGui::SameLine();
   ImGui::TextDisabled("(%s)", stateName);
@@ -63,6 +71,12 @@ void drawRocketDetailWindow(flecs::entity winE) {
       if (ImGui::SmallButton("View##building")) {
         showBuildingDetailWindow(buildingE);
       }
+      ImGui::SameLine();
+      openMovePopup = Widgets::ActionButton(
+          ButtonLabel{.text = "Move"},
+          ButtonTooltip{.text =
+                            "Move the rocket to another storage at this site"},
+          actionIssue, true);
     } else if (facilityE.is_valid()) {
       ImGui::TextUnformatted(facilityE.name().c_str());
     } else {
@@ -80,6 +94,13 @@ void drawRocketDetailWindow(flecs::entity winE) {
       }
     } else {
       ImGui::TextUnformatted("None");
+      ImGui::SameLine();
+      if (Widgets::ActionButton(
+              ButtonLabel{.text = "Schedule"},
+              ButtonTooltip{.text = "Schedule the rocket for launch"},
+              actionIssue, true)) {
+        showLaunchWindowAdd(world, &state.rocket, nullptr);
+      }
     }
     ImGui::Spacing();
 
@@ -129,54 +150,28 @@ void drawRocketDetailWindow(flecs::entity winE) {
     ImGui::EndTable();
   }
 
-  ImGui::Spacing();
-  ImGui::Separator();
-
-  drawRocketButtons(state.rocket);
-  ImGui::SameLine();
-  if (ImGui::Button("Close")) {
-    hideWindow(world, "Rocket Detail");
-    state.rocket = flecs::entity::null();
-  }
-}
-
-void drawRocketButtons(flecs::entity &rocket) {
-  std::string issue;
-  if (!rocket.has<RocketCurrentState>(
-          rocket.world().lookup("States::Rocket::Stored"))) {
-    issue = "Rocket is not available";
-  }
-
-  bool openPopup = Widgets::ActionButton(
-      ButtonLabel{.text = "Move"},
-      ButtonTooltip{.text = "Move the rocket to another storage at this site"},
-      issue);
-  ImGui::SameLine();
-
-  auto target = rocket.target<LaunchingOn>();
-  std::string tooltip =
-      target.is_valid() ? "View launch plan" : "Schedule the rocket for launch";
-  if (Widgets::ActionButton(
-          ButtonLabel{.text = target.is_valid() ? "View Plan" : "Schedule"},
-          ButtonTooltip{.text = tooltip.c_str()}, issue)) {
-    if (target.is_valid()) {
-      showLaunchDetailWindow(target);
-    } else {
-      showLaunchWindowAdd(rocket.world(), &rocket, nullptr);
-    }
-  }
-  auto world = rocket.world();
-  auto currentStorage = rocket.parent();
+  auto currentStorage = state.rocket.parent();
   auto site = findAncestorWith<Site>(currentStorage);
   if (site.is_valid()) {
-    auto moveDurationDays =
-        static_cast<uint8_t>(rocket.get<Rocket>().move_days.value());
-    storagePickerPopup("Move Rocket", openPopup, world, currentStorage,
+    auto moveDurationDays = static_cast<uint8_t>(rocketData.move_days.value());
+    storagePickerPopup("Move Rocket", openMovePopup, world, currentStorage,
                        [&](flecs::entity dest) {
-                         RocketMoveAction action{RocketEntity{rocket},
+                         RocketMoveAction action{RocketEntity{state.rocket},
                                                  DestinationEntity{dest},
                                                  moveDurationDays};
                          action.execute(world);
                        });
+  }
+
+  ImGui::Spacing();
+  ImGui::Separator();
+
+  float closeWidth =
+      ImGui::CalcTextSize("Close").x + ImGui::GetStyle().FramePadding.x * 2.0f;
+  ImGui::SetCursorPosX(ImGui::GetWindowWidth() - closeWidth -
+                       ImGui::GetStyle().WindowPadding.x);
+  if (ImGui::Button("Close")) {
+    hideWindow(world, "Rocket Detail");
+    state.rocket = flecs::entity::null();
   }
 }

--- a/src/modules/window/rocket_detail_window.cpp
+++ b/src/modules/window/rocket_detail_window.cpp
@@ -13,6 +13,7 @@
 #include "widgets/stat_widget.h"
 #include "widgets/widgets.h"
 #include <flecs.h>
+#include <format>
 #include <functional>
 
 void showRocketDetailWindow(flecs::entity rocketE) {
@@ -59,6 +60,26 @@ void drawRocketDetailWindow(flecs::entity winE) {
     }
   }
   ImGui::Separator();
+
+  {
+    float fraction = -1.0f;
+    if (state.rocket.has<EffortRequired>()) {
+      const auto &e = state.rocket.get<EffortRequired>();
+      fraction = e.total > 0 ? static_cast<float>(e.total - e.remaining) /
+                                   static_cast<float>(e.total)
+                             : 0.0f;
+    } else if (state.rocket.has<DurationRequired>()) {
+      const auto &d = state.rocket.get<DurationRequired>();
+      fraction = d.total > 0 ? static_cast<float>(d.total - d.remaining) /
+                                   static_cast<float>(d.total)
+                             : 0.0f;
+    }
+    if (fraction >= 0.0f) {
+      auto label = std::format("{:.0f}%", fraction * 100.0f);
+      ImGui::ProgressBar(fraction, ImVec2(-1, 0), label.c_str());
+      ImGui::Spacing();
+    }
+  }
 
   if (ImGui::BeginTable("##rocketDetailLayout", 2,
                         ImGuiTableFlags_SizingStretchProp)) {

--- a/src/modules/window/rocket_detail_window.cpp
+++ b/src/modules/window/rocket_detail_window.cpp
@@ -146,8 +146,7 @@ void drawRocketDetailWindow(flecs::entity winE) {
 
     ImGui::TextDisabled("Stats");
     Widgets::StatTooltip(&rocketData.failure_rate);
-    Widgets::StatTooltip(&rocketData.cost,
-                         [](double v) { return "$" + format_locale(v); });
+    Widgets::StatTooltip(&rocketData.cost);
     Widgets::StatTooltip(&rocketData.rollout_days);
     Widgets::StatTooltip(&rocketData.move_days);
 

--- a/src/modules/window/rocket_detail_window.cpp
+++ b/src/modules/window/rocket_detail_window.cpp
@@ -9,6 +9,7 @@
 #include "modules/rocket/rocket_actions.h"
 #include "modules/rocket/rocket_module.h"
 #include "modules/site/site.h"
+#include "storage_picker.h"
 #include "widgets/stat_widget.h"
 #include "widgets/widgets.h"
 #include <flecs.h>
@@ -166,10 +167,6 @@ void drawRocketDetailWindow(flecs::entity winE) {
   ImGui::Spacing();
   ImGui::Separator();
 
-  float closeWidth =
-      ImGui::CalcTextSize("Close").x + ImGui::GetStyle().FramePadding.x * 2.0f;
-  ImGui::SetCursorPosX(ImGui::GetWindowWidth() - closeWidth -
-                       ImGui::GetStyle().WindowPadding.x);
   if (ImGui::Button("Close")) {
     hideWindow(world, "Rocket Detail");
     state.rocket = flecs::entity::null();

--- a/src/modules/window/rocket_detail_window.cpp
+++ b/src/modules/window/rocket_detail_window.cpp
@@ -73,11 +73,11 @@ void drawRocketDetailWindow(flecs::entity winE) {
         showBuildingDetailWindow(buildingE);
       }
       ImGui::SameLine();
-      openMovePopup = Widgets::ActionButton(
+      openMovePopup = Widgets::SmallActionButton(
           ButtonLabel{.text = "Move"},
           ButtonTooltip{.text =
                             "Move the rocket to another storage at this site"},
-          actionIssue, true);
+          actionIssue);
     } else if (facilityE.is_valid()) {
       ImGui::TextUnformatted(facilityE.name().c_str());
     } else {
@@ -96,10 +96,10 @@ void drawRocketDetailWindow(flecs::entity winE) {
     } else {
       ImGui::TextUnformatted("None");
       ImGui::SameLine();
-      if (Widgets::ActionButton(
+      if (Widgets::SmallActionButton(
               ButtonLabel{.text = "Schedule"},
               ButtonTooltip{.text = "Schedule the rocket for launch"},
-              actionIssue, true)) {
+              actionIssue)) {
         showLaunchWindowAdd(world, &state.rocket, nullptr);
       }
     }

--- a/src/modules/window/rocket_detail_window.h
+++ b/src/modules/window/rocket_detail_window.h
@@ -7,4 +7,3 @@ struct RocketDetailWindow {
 
 void showRocketDetailWindow(flecs::entity rocketE);
 void drawRocketDetailWindow(flecs::entity winE);
-void drawRocketButtons(flecs::entity &rocket);

--- a/src/modules/window/rocket_detail_window.h
+++ b/src/modules/window/rocket_detail_window.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <flecs.h>
+
+struct RocketDetailWindow {
+  flecs::entity rocket = flecs::entity::null();
+};
+
+void showRocketDetailWindow(flecs::entity rocketE);
+void drawRocketDetailWindow(flecs::entity winE);
+void drawRocketButtons(flecs::entity &rocket);

--- a/src/modules/window/rocket_list_window.cpp
+++ b/src/modules/window/rocket_list_window.cpp
@@ -6,6 +6,7 @@
 #include "modules/site/site.h"
 #include "rocket_detail_window.h"
 #include <flecs.h>
+#include <string>
 
 bool rocketMatchesFilter(flecs::entity rocketE, const RocketListWindow &state) {
   auto stateE = rocketE.target<RocketCurrentState>();
@@ -89,6 +90,16 @@ void drawRocketListWindow(flecs::entity winE) {
                   ? stateE.get<Label>().label.c_str()
                   : (stateE.is_valid() ? stateE.name().c_str() : "-");
           ImGui::TextUnformatted(stateLabel);
+          if (rocketE.has<RocketStateTransitionBlocked>()) {
+            const auto &blocked = rocketE.get<RocketStateTransitionBlocked>();
+            ImGui::SameLine();
+            ImGui::TextColored((ImVec4)ImColor::HSV(0.13f, 1.0f, 1.0f),
+                               "\xef\x81\xb1"); // fa-triangle-exclamation f071
+            if (ImGui::BeginItemTooltip()) {
+              ImGui::Text("%s", blocked.reason.c_str());
+              ImGui::EndTooltip();
+            }
+          }
 
           ImGui::TableSetColumnIndex(2);
           auto facilityE = rocketE.parent();

--- a/src/modules/window/rocket_list_window.cpp
+++ b/src/modules/window/rocket_list_window.cpp
@@ -61,7 +61,8 @@ void drawRocketListWindow(flecs::entity winE) {
   // --- Table ---
   constexpr ImGuiTableFlags tableFlags =
       ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
-      ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_ScrollY;
+      ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_ScrollY |
+      ImGuiTableFlags_Resizable;
 
   if (ImGui::BeginTable("rockets", 4, tableFlags)) {
     ImGui::TableSetupScrollFreeze(0, 1);

--- a/src/modules/window/rocket_list_window.cpp
+++ b/src/modules/window/rocket_list_window.cpp
@@ -89,7 +89,23 @@ void drawRocketListWindow(flecs::entity winE) {
               stateE.is_valid() && stateE.has<Label>()
                   ? stateE.get<Label>().label.c_str()
                   : (stateE.is_valid() ? stateE.name().c_str() : "-");
-          ImGui::TextUnformatted(stateLabel);
+          float fraction = -1.0f;
+          if (rocketE.has<EffortRequired>()) {
+            const auto &e = rocketE.get<EffortRequired>();
+            fraction = e.total > 0 ? static_cast<float>(e.total - e.remaining) /
+                                         static_cast<float>(e.total)
+                                   : 0.0f;
+          } else if (rocketE.has<DurationRequired>()) {
+            const auto &d = rocketE.get<DurationRequired>();
+            fraction = d.total > 0 ? static_cast<float>(d.total - d.remaining) /
+                                         static_cast<float>(d.total)
+                                   : 0.0f;
+          }
+          if (fraction >= 0.0f) {
+            ImGui::ProgressBar(fraction, ImVec2(-1, 0), stateLabel);
+          } else {
+            ImGui::TextUnformatted(stateLabel);
+          }
           if (rocketE.has<RocketStateTransitionBlocked>()) {
             const auto &blocked = rocketE.get<RocketStateTransitionBlocked>();
             ImGui::SameLine();

--- a/src/modules/window/rocket_list_window.cpp
+++ b/src/modules/window/rocket_list_window.cpp
@@ -1,18 +1,63 @@
 #include "rocket_list_window.h"
 #include "imgui.h"
+#include "modules/base/base.h"
 #include "modules/engine/gui.h"
 #include "modules/rocket/rocket_module.h"
 #include "modules/site/site.h"
 #include "rocket_detail_window.h"
 #include <flecs.h>
 
+bool rocketMatchesFilter(flecs::entity rocketE, const RocketListWindow &state) {
+  auto stateE = rocketE.target<RocketCurrentState>();
+  if (state.hideTerminal && stateE.is_valid() &&
+      stateE.has<StateIsTerminal>()) {
+    return false;
+  }
+  if (!state.stateFilter.is_valid()) {
+    return true;
+  }
+  return rocketE.has<RocketCurrentState>(state.stateFilter);
+}
+
 void showRocketListWindow(flecs::world &world) {
   showWindow(world, "Rocket List");
 }
 
 void drawRocketListWindow(flecs::entity winE) {
+  auto &state = winE.get_mut<RocketListWindow>();
   auto world = winE.world();
 
+  // --- Filter ---
+  const char *filterPreview = "All";
+  if (state.stateFilter.is_valid() && state.stateFilter.is_alive()) {
+    filterPreview = state.stateFilter.has<Label>()
+                        ? state.stateFilter.get<Label>().label.c_str()
+                        : state.stateFilter.name().c_str();
+  }
+  ImGui::SetNextItemWidth(150.0f);
+  if (ImGui::BeginCombo("##StateFilter", filterPreview)) {
+    if (ImGui::Selectable("All", !state.stateFilter.is_valid())) {
+      state.stateFilter = flecs::entity::null();
+    }
+    auto rocketStates = world.lookup("States::Rocket");
+    if (rocketStates.is_valid()) {
+      rocketStates.children([&](flecs::entity stateE) {
+        if (!stateE.has<Label>()) {
+          return;
+        }
+        const char *label = stateE.get<Label>().label.c_str();
+        if (ImGui::Selectable(label, state.stateFilter == stateE)) {
+          state.stateFilter = stateE;
+        }
+      });
+    }
+    ImGui::EndCombo();
+  }
+  ImGui::SameLine();
+  ImGui::Checkbox("Hide retired", &state.hideTerminal);
+  ImGui::Separator();
+
+  // --- Table ---
   constexpr ImGuiTableFlags tableFlags =
       ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
       ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_ScrollY;
@@ -25,37 +70,45 @@ void drawRocketListWindow(flecs::entity winE) {
     ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, 40.0f);
     ImGui::TableHeadersRow();
 
-    world.query_builder<Rocket>().build().each([&](flecs::entity rocketE,
-                                                   Rocket &) {
-      ImGui::TableNextRow();
-      ImGui::PushID(std::to_string(rocketE.id()).c_str());
+    world.query_builder<Rocket>().build().each(
+        [&](flecs::entity rocketE, Rocket &) {
+          if (!rocketMatchesFilter(rocketE, state)) {
+            return;
+          }
 
-      ImGui::TableSetColumnIndex(0);
-      ImGui::TextUnformatted(rocketE.name().c_str());
+          ImGui::TableNextRow();
+          ImGui::PushID(std::to_string(rocketE.id()).c_str());
 
-      ImGui::TableSetColumnIndex(1);
-      auto stateE = rocketE.target<RocketCurrentState>();
-      ImGui::TextUnformatted(stateE.is_valid() ? stateE.name().c_str() : "-");
+          ImGui::TableSetColumnIndex(0);
+          ImGui::TextUnformatted(rocketE.name().c_str());
 
-      ImGui::TableSetColumnIndex(2);
-      auto facilityE = rocketE.parent();
-      auto buildingE =
-          facilityE.is_valid() ? facilityE.parent() : flecs::entity();
-      if (buildingE.is_valid() && buildingE.has<Building>()) {
-        ImGui::TextUnformatted(buildingE.name().c_str());
-      } else if (facilityE.is_valid()) {
-        ImGui::TextUnformatted(facilityE.name().c_str());
-      } else {
-        ImGui::TextDisabled("-");
-      }
+          ImGui::TableSetColumnIndex(1);
+          auto stateE = rocketE.target<RocketCurrentState>();
+          const char *stateLabel =
+              stateE.is_valid() && stateE.has<Label>()
+                  ? stateE.get<Label>().label.c_str()
+                  : (stateE.is_valid() ? stateE.name().c_str() : "-");
+          ImGui::TextUnformatted(stateLabel);
 
-      ImGui::TableSetColumnIndex(3);
-      if (ImGui::SmallButton("View")) {
-        showRocketDetailWindow(rocketE);
-      }
+          ImGui::TableSetColumnIndex(2);
+          auto facilityE = rocketE.parent();
+          auto buildingE =
+              facilityE.is_valid() ? facilityE.parent() : flecs::entity();
+          if (buildingE.is_valid() && buildingE.has<Building>()) {
+            ImGui::TextUnformatted(buildingE.name().c_str());
+          } else if (facilityE.is_valid()) {
+            ImGui::TextUnformatted(facilityE.name().c_str());
+          } else {
+            ImGui::TextDisabled("-");
+          }
 
-      ImGui::PopID();
-    });
+          ImGui::TableSetColumnIndex(3);
+          if (ImGui::SmallButton("View")) {
+            showRocketDetailWindow(rocketE);
+          }
+
+          ImGui::PopID();
+        });
 
     ImGui::EndTable();
   }

--- a/src/modules/window/rocket_list_window.cpp
+++ b/src/modules/window/rocket_list_window.cpp
@@ -1,0 +1,62 @@
+#include "rocket_list_window.h"
+#include "imgui.h"
+#include "modules/engine/gui.h"
+#include "modules/rocket/rocket_module.h"
+#include "modules/site/site.h"
+#include "rocket_detail_window.h"
+#include <flecs.h>
+
+void showRocketListWindow(flecs::world &world) {
+  showWindow(world, "Rocket List");
+}
+
+void drawRocketListWindow(flecs::entity winE) {
+  auto world = winE.world();
+
+  constexpr ImGuiTableFlags tableFlags =
+      ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+      ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_ScrollY;
+
+  if (ImGui::BeginTable("rockets", 4, tableFlags)) {
+    ImGui::TableSetupScrollFreeze(0, 1);
+    ImGui::TableSetupColumn("Name");
+    ImGui::TableSetupColumn("State", ImGuiTableColumnFlags_WidthFixed, 130.0f);
+    ImGui::TableSetupColumn("Location");
+    ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, 40.0f);
+    ImGui::TableHeadersRow();
+
+    world.query_builder<Rocket>().build().each([&](flecs::entity rocketE,
+                                                   Rocket &) {
+      ImGui::TableNextRow();
+      ImGui::PushID(std::to_string(rocketE.id()).c_str());
+
+      ImGui::TableSetColumnIndex(0);
+      ImGui::TextUnformatted(rocketE.name().c_str());
+
+      ImGui::TableSetColumnIndex(1);
+      auto stateE = rocketE.target<RocketCurrentState>();
+      ImGui::TextUnformatted(stateE.is_valid() ? stateE.name().c_str() : "-");
+
+      ImGui::TableSetColumnIndex(2);
+      auto facilityE = rocketE.parent();
+      auto buildingE =
+          facilityE.is_valid() ? facilityE.parent() : flecs::entity();
+      if (buildingE.is_valid() && buildingE.has<Building>()) {
+        ImGui::TextUnformatted(buildingE.name().c_str());
+      } else if (facilityE.is_valid()) {
+        ImGui::TextUnformatted(facilityE.name().c_str());
+      } else {
+        ImGui::TextDisabled("-");
+      }
+
+      ImGui::TableSetColumnIndex(3);
+      if (ImGui::SmallButton("View")) {
+        showRocketDetailWindow(rocketE);
+      }
+
+      ImGui::PopID();
+    });
+
+    ImGui::EndTable();
+  }
+}

--- a/src/modules/window/rocket_list_window.h
+++ b/src/modules/window/rocket_list_window.h
@@ -1,7 +1,13 @@
 #pragma once
 #include <flecs.h>
 
-struct RocketListWindow {};
+struct RocketListWindow {
+  flecs::entity stateFilter = flecs::entity::null();
+  bool hideTerminal = true;
+};
 
 void showRocketListWindow(flecs::world &world);
 void drawRocketListWindow(flecs::entity winE);
+
+/// @brief Returns true if the rocket should appear given the current filter.
+bool rocketMatchesFilter(flecs::entity rocketE, const RocketListWindow &state);

--- a/src/modules/window/rocket_list_window.h
+++ b/src/modules/window/rocket_list_window.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <flecs.h>
+
+struct RocketListWindow {};
+
+void showRocketListWindow(flecs::world &world);
+void drawRocketListWindow(flecs::entity winE);

--- a/src/modules/window/storage_picker.cpp
+++ b/src/modules/window/storage_picker.cpp
@@ -1,0 +1,55 @@
+#include "storage_picker.h"
+#include "imgui.h"
+#include "modules/site/site.h"
+#include "widgets/widgets.h"
+#include <flecs.h>
+
+void storagePickerPopup(const char *popupId, bool open, flecs::world &world,
+                        flecs::entity excluded,
+                        const std::function<void(flecs::entity)> &onConfirm) {
+  static flecs::entity destination;
+  static std::string display = "<Select one>";
+  if (open) {
+    destination = flecs::entity();
+    display = "<Select one>";
+    ImGui::OpenPopup(popupId);
+  }
+  if (!ImGui::BeginPopupModal(popupId)) {
+    return;
+  }
+  ImGui::Text("Where to?");
+  ImGui::SameLine();
+
+  auto storageFacilities =
+      world.query_builder().with<Storage>().with<Site>().up().build();
+
+  if (ImGui::BeginCombo("##StorageCombo", display.c_str())) {
+    storageFacilities.each([&](flecs::entity s) {
+      ImGui::BeginDisabled(excluded.is_valid() && s == excluded);
+      if (ImGui::Selectable(s.parent().name().c_str(), destination == s)) {
+        destination = s;
+        display = s.parent().name();
+      }
+      ImGui::EndDisabled();
+    });
+    ImGui::EndCombo();
+  }
+  ImGui::Separator();
+  if (ImGui::Button("Cancel")) {
+    ImGui::CloseCurrentPopup();
+  }
+  ImGui::SameLine();
+  std::string issue;
+  if (!destination.is_valid()) {
+    issue = "Select a destination";
+  } else if (destination == excluded) {
+    issue = "Already here";
+  }
+  if (Widgets::ActionButton(ButtonLabel{.text = "Ok"},
+                            ButtonTooltip{.text = "Confirm selection"},
+                            issue)) {
+    onConfirm(destination);
+    ImGui::CloseCurrentPopup();
+  }
+  ImGui::EndPopup();
+}

--- a/src/modules/window/storage_picker.h
+++ b/src/modules/window/storage_picker.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <flecs.h>
+#include <functional>
+
+void storagePickerPopup(const char *popupId, bool open, flecs::world &world,
+                        flecs::entity excluded,
+                        const std::function<void(flecs::entity)> &onConfirm);

--- a/src/modules/window/toolbar.cpp
+++ b/src/modules/window/toolbar.cpp
@@ -7,6 +7,7 @@
 #include <modules/rocket/active_launches_window.h>
 #include <modules/rocket/contracts_window.h>
 #include <modules/window/notification_window.h>
+#include <modules/window/rocket_list_window.h>
 
 void systemDrawToolbar(flecs::entity winE, Toolbar) {
   auto world = winE.world();
@@ -20,6 +21,11 @@ void systemDrawToolbar(flecs::entity winE, Toolbar) {
   if (ImGui::BeginViewportSideBar("##Toolbar", viewport, ImGuiDir_Up, height,
                                   toolbar_flags)) {
     if (ImGui::BeginMenuBar()) {
+      if (ImGui::Button("\xef\x92\x94")) { // fa-warehouse f494
+        showRocketListWindow(world);
+      }
+      ImGui::SetItemTooltip("Rocket Fleet");
+      ImGui::SameLine();
       if (ImGui::Button("\xef\x84\xb5")) { // fa-rocket f135
         showActiveLaunchesWindow(world);
       }

--- a/src/modules/window/window_module.cpp
+++ b/src/modules/window/window_module.cpp
@@ -38,7 +38,7 @@ WindowModule::WindowModule(flecs::world &world) {
         registerWindow("Rocket Detail", drawRocketDetailWindow, w)
             .set<RocketDetailWindow>({});
         registerWindow("Rocket List", drawRocketListWindow, w)
-            .add<RocketListWindow>();
+            .set<RocketListWindow>({});
       });
 
   // Register Systems

--- a/src/modules/window/window_module.cpp
+++ b/src/modules/window/window_module.cpp
@@ -5,6 +5,7 @@
 #include "modules/engine/gui.h"
 #include "modules/engine/input.h"
 #include "notification_window.h"
+#include "rocket_detail_window.h"
 #include "toolbar.h"
 #include <flecs.h>
 #include <modules/simulation/simulation.h>
@@ -14,6 +15,7 @@ WindowModule::WindowModule(flecs::world &world) {
   // Register components
   world.component<MainMenuBar>();
   world.component<Toolbar>();
+  world.component<RocketDetailWindow>();
   world.component<NotificationWindow>()
       .member("severity_filter", &NotificationWindow::severity_filter)
       .member("category_filter", &NotificationWindow::category_filter)
@@ -25,12 +27,14 @@ WindowModule::WindowModule(flecs::world &world) {
 
   // Must be registered in OnStart (outside module scope) so the entity is
   // parented to the root "Windows" node, not the WindowModule entity.
-  world.system("Register Notification Window")
+  world.system("Register Windows")
       .kind(flecs::OnStart)
       .run([](flecs::iter &it) {
         auto w = it.world();
         registerWindow("Notifications", drawNotificationWindow, w)
             .set<NotificationWindow>({});
+        registerWindow("Rocket Detail", drawRocketDetailWindow, w)
+            .set<RocketDetailWindow>({});
       });
 
   // Register Systems

--- a/src/modules/window/window_module.cpp
+++ b/src/modules/window/window_module.cpp
@@ -6,6 +6,7 @@
 #include "modules/engine/input.h"
 #include "notification_window.h"
 #include "rocket_detail_window.h"
+#include "rocket_list_window.h"
 #include "toolbar.h"
 #include <flecs.h>
 #include <modules/simulation/simulation.h>
@@ -16,6 +17,7 @@ WindowModule::WindowModule(flecs::world &world) {
   world.component<MainMenuBar>();
   world.component<Toolbar>();
   world.component<RocketDetailWindow>();
+  world.component<RocketListWindow>();
   world.component<NotificationWindow>()
       .member("severity_filter", &NotificationWindow::severity_filter)
       .member("category_filter", &NotificationWindow::category_filter)
@@ -35,6 +37,8 @@ WindowModule::WindowModule(flecs::world &world) {
             .set<NotificationWindow>({});
         registerWindow("Rocket Detail", drawRocketDetailWindow, w)
             .set<RocketDetailWindow>({});
+        registerWindow("Rocket List", drawRocketListWindow, w)
+            .add<RocketListWindow>();
       });
 
   // Register Systems

--- a/src/widgets/stat_widget.cpp
+++ b/src/widgets/stat_widget.cpp
@@ -1,28 +1,27 @@
 #include "stat_widget.h"
 #include "imgui.h"
 #include <format>
-#include <functional>
 
 namespace Widgets {
 
-void StatTooltip(const Stat *stat,
-                 const std::function<std::string(double)> &fmt) {
-  ImGui::Text("%s: %s", stat->display().c_str(), fmt(stat->value()).c_str());
+void StatTooltip(const Stat *stat) {
+  ImGui::Text("%s: %s", stat->display().c_str(),
+              stat->format(stat->value()).c_str());
 
   if (ImGui::BeginItemTooltip()) {
     ImGui::Text("%s", stat->description().c_str());
     ImGui::Separator();
-    ImGui::Text("Base Value: %s", fmt(stat->base()).c_str());
+    ImGui::Text("Base Value: %s", stat->format(stat->base()).c_str());
     constexpr ImVec4 red = ImVec4(1.0, 0.0, 0.0, 1.0);
     constexpr ImVec4 green = ImVec4(0.0, 0.5, 0.0, 1.0);
     for (const auto &item : stat->modifiers()) {
       std::string modValue = "";
       ImVec4 colour;
       if (item.mod.additive > 0) {
-        modValue = "+" + fmt(item.mod.additive);
+        modValue = "+" + stat->format(item.mod.additive);
         colour = stat->isHigherBetter() ? green : red;
       } else if (item.mod.additive < 0) {
-        modValue = fmt(item.mod.additive);
+        modValue = stat->format(item.mod.additive);
         colour = stat->isHigherBetter() ? red : green;
       }
       if (item.mod.multiplicative > 1) {
@@ -39,7 +38,7 @@ void StatTooltip(const Stat *stat,
       }
     }
     ImGui::Separator();
-    ImGui::Text("Final Value: %s", fmt(stat->value()).c_str());
+    ImGui::Text("Final Value: %s", stat->format(stat->value()).c_str());
     ImGui::EndTooltip();
   }
 }

--- a/src/widgets/stat_widget.h
+++ b/src/widgets/stat_widget.h
@@ -1,12 +1,7 @@
 #pragma once
 
 #include "modules/stats/stats.h"
-#include <format>
-#include <functional>
-#include <string>
 
 namespace Widgets {
-void StatTooltip(
-    const Stat *stat, const std::function<std::string(double)> &fmt =
-                          [](double v) { return std::format("{:.0f}", v); });
+void StatTooltip(const Stat *stat);
 } // namespace Widgets

--- a/src/widgets/widgets.cpp
+++ b/src/widgets/widgets.cpp
@@ -3,11 +3,11 @@
 
 namespace Widgets {
 
-bool ActionButton(ButtonLabel label, ButtonTooltip tooltip,
-                  const std::string &issue, bool small) {
-  bool retval = false;
+namespace {
+bool actionButtonImpl(bool small, ButtonLabel label, ButtonTooltip tooltip,
+                      const std::string &issue) {
   ImGui::BeginDisabled(!issue.empty());
-  retval = small ? ImGui::SmallButton(label.text) : ImGui::Button(label.text);
+  bool retval = small ? ImGui::SmallButton(label.text) : ImGui::Button(label.text);
   if ((tooltip.text || !issue.empty()) && ImGui::BeginItemTooltip()) {
     if (tooltip.text) {
       ImGui::Text("%s", tooltip.text);
@@ -20,6 +20,17 @@ bool ActionButton(ButtonLabel label, ButtonTooltip tooltip,
   }
   ImGui::EndDisabled();
   return retval;
+}
+} // namespace
+
+bool ActionButton(ButtonLabel label, ButtonTooltip tooltip,
+                  const std::string &issue) {
+  return actionButtonImpl(false, label, tooltip, issue);
+}
+
+bool SmallActionButton(ButtonLabel label, ButtonTooltip tooltip,
+                       const std::string &issue) {
+  return actionButtonImpl(true, label, tooltip, issue);
 }
 
 void NotImplementedPopup() {

--- a/src/widgets/widgets.cpp
+++ b/src/widgets/widgets.cpp
@@ -7,7 +7,8 @@ namespace {
 bool actionButtonImpl(bool small, ButtonLabel label, ButtonTooltip tooltip,
                       const std::string &issue) {
   ImGui::BeginDisabled(!issue.empty());
-  bool retval = small ? ImGui::SmallButton(label.text) : ImGui::Button(label.text);
+  bool retval =
+      small ? ImGui::SmallButton(label.text) : ImGui::Button(label.text);
   if ((tooltip.text || !issue.empty()) && ImGui::BeginItemTooltip()) {
     if (tooltip.text) {
       ImGui::Text("%s", tooltip.text);

--- a/src/widgets/widgets.cpp
+++ b/src/widgets/widgets.cpp
@@ -4,18 +4,18 @@
 namespace Widgets {
 
 bool ActionButton(ButtonLabel label, ButtonTooltip tooltip,
-                  const std::string &issue) {
+                  const std::string &issue, bool small) {
   bool retval = false;
   ImGui::BeginDisabled(!issue.empty());
-  if (ImGui::Button(label.text)) {
-    retval = true;
-  }
+  retval = small ? ImGui::SmallButton(label.text) : ImGui::Button(label.text);
   if ((tooltip.text || !issue.empty()) && ImGui::BeginItemTooltip()) {
-    if (tooltip.text)
+    if (tooltip.text) {
       ImGui::Text("%s", tooltip.text);
-    if (!issue.empty())
+    }
+    if (!issue.empty()) {
       ImGui::TextColored((ImVec4)ImColor::HSV(1.0, 1.0, 1.0), "%s",
                          issue.c_str());
+    }
     ImGui::EndTooltip();
   }
   ImGui::EndDisabled();

--- a/src/widgets/widgets.h
+++ b/src/widgets/widgets.h
@@ -11,6 +11,7 @@ struct ButtonTooltip {
 };
 
 namespace Widgets {
-bool ActionButton(ButtonLabel, ButtonTooltip, const std::string &issue);
+bool ActionButton(ButtonLabel, ButtonTooltip, const std::string &issue,
+                  bool small = false);
 void NotImplementedPopup();
 } // namespace Widgets

--- a/src/widgets/widgets.h
+++ b/src/widgets/widgets.h
@@ -11,7 +11,7 @@ struct ButtonTooltip {
 };
 
 namespace Widgets {
-bool ActionButton(ButtonLabel, ButtonTooltip, const std::string &issue,
-                  bool small = false);
+bool ActionButton(ButtonLabel, ButtonTooltip, const std::string &issue);
+bool SmallActionButton(ButtonLabel, ButtonTooltip, const std::string &issue);
 void NotImplementedPopup();
 } // namespace Widgets

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,7 @@ add_executable(unit_test
   stats/stats.test.cpp
   window/building_detail_window.test.cpp
   window/notification_window.test.cpp
+  window/rocket_list_window.test.cpp
 )
 target_link_libraries(unit_test PRIVATE Catch2::Catch2)
 target_link_libraries(unit_test PRIVATE solcorplib)

--- a/test/stats/stats.test.cpp
+++ b/test/stats/stats.test.cpp
@@ -47,3 +47,40 @@ SCENARIO("Stats", "[stats]") {
     }
   }
 }
+
+SCENARIO("Stat formatting", "[stats]") {
+  GIVEN("a default number stat") {
+    Stat stat{{.id = "count",
+               .display = "Count",
+               .description = "A plain number",
+               .base = 12.4}};
+
+    THEN("it formats as a rounded number") {
+      REQUIRE(stat.format(12.4) == "12");
+    }
+  }
+
+  GIVEN("a currency stat") {
+    Stat stat{{.id = "cost",
+               .display = "Cost",
+               .description = "A money value",
+               .base = 1'250,
+               .format = Stat::Format::Currency}};
+
+    THEN("it formats with a dollar prefix and separators") {
+      REQUIRE(stat.format(1250) == "$1,250");
+    }
+  }
+
+  GIVEN("a percentage stat") {
+    Stat stat{{.id = "failure-rate",
+               .display = "Failure Rate",
+               .description = "A probability",
+               .base = 0.1,
+               .format = Stat::Format::Percentage}};
+
+    THEN("it formats probabilities as whole percentages") {
+      REQUIRE(stat.format(stat.base()) == "10%");
+    }
+  }
+}

--- a/test/window/rocket_list_window.test.cpp
+++ b/test/window/rocket_list_window.test.cpp
@@ -1,0 +1,92 @@
+#include "modules/window/rocket_list_window.h"
+#include "modules/base/base.h"
+#include "modules/rocket/rocket_module.h"
+#include <catch2/catch_test_macros.hpp>
+#include <flecs.h>
+
+namespace {
+struct WorldFixture {
+  flecs::world world;
+  flecs::entity stored;
+  flecs::entity invalid;
+
+  WorldFixture() {
+    world.component<StateIsTerminal>();
+    world.component<RocketCurrentState>().add(flecs::Exclusive);
+    world.component<Rocket>();
+
+    auto scope = world.set_scope(0);
+    auto statesRoot = world.entity("States");
+    auto rocketStates = world.entity("Rocket").child_of(statesRoot);
+    stored = world.entity("Stored").child_of(rocketStates);
+    invalid =
+        world.entity("Invalid").child_of(rocketStates).add<StateIsTerminal>();
+    world.set_scope(scope);
+  }
+
+  flecs::entity makeRocket(flecs::entity state) {
+    return world.entity().add<Rocket>().add<RocketCurrentState>(state);
+  }
+};
+} // namespace
+
+SCENARIO("rocketMatchesFilter", "[window]") {
+  WorldFixture f;
+
+  GIVEN("no state filter and hideTerminal=false") {
+    RocketListWindow state{.stateFilter = flecs::entity::null(),
+                           .hideTerminal = false};
+
+    WHEN("the rocket is in a normal state") {
+      auto rocket = f.makeRocket(f.stored);
+      THEN("it matches") { REQUIRE(rocketMatchesFilter(rocket, state)); }
+    }
+    WHEN("the rocket is in a terminal state") {
+      auto rocket = f.makeRocket(f.invalid);
+      THEN("it matches") { REQUIRE(rocketMatchesFilter(rocket, state)); }
+    }
+  }
+
+  GIVEN("no state filter and hideTerminal=true") {
+    RocketListWindow state{.stateFilter = flecs::entity::null(),
+                           .hideTerminal = true};
+
+    WHEN("the rocket is in a normal state") {
+      auto rocket = f.makeRocket(f.stored);
+      THEN("it matches") { REQUIRE(rocketMatchesFilter(rocket, state)); }
+    }
+    WHEN("the rocket is in a terminal state") {
+      auto rocket = f.makeRocket(f.invalid);
+      THEN("it is excluded") {
+        REQUIRE_FALSE(rocketMatchesFilter(rocket, state));
+      }
+    }
+  }
+
+  GIVEN("a state filter is set") {
+    RocketListWindow state{.stateFilter = f.stored, .hideTerminal = false};
+
+    WHEN("the rocket is in the filtered state") {
+      auto rocket = f.makeRocket(f.stored);
+      THEN("it matches") { REQUIRE(rocketMatchesFilter(rocket, state)); }
+    }
+    WHEN("the rocket is in a different state") {
+      auto rocket = f.makeRocket(f.invalid);
+      THEN("it is excluded") {
+        REQUIRE_FALSE(rocketMatchesFilter(rocket, state));
+      }
+    }
+  }
+
+  GIVEN(
+      "hideTerminal=true and a state filter is also set to a terminal state") {
+    RocketListWindow state{.stateFilter = f.invalid, .hideTerminal = true};
+
+    WHEN("the rocket is in that terminal state") {
+      auto rocket = f.makeRocket(f.invalid);
+      THEN("hideTerminal takes priority and excludes it") {
+        REQUIRE_FALSE(rocketMatchesFilter(rocket, state));
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Rocket detail window showing rocket stats, state, location, and assigned launch plan with action buttons
- Rocket list window listing all rockets with state, location, and a View button; filterable by state with a "hide retired" toggle
- State transition progress bar in both windows when a rocket is under construction or moving, showing percentage complete (detail) or state
- Blocked state indicator of yellow warning triangle with tooltip showing the reason when RocketStateTransitionBlocked is set, in both windows
 - Extracted Storage picker popup for selecting a storage destination, used by the Move action in the rocket detail window
 - Small action buttons 
 - Stat now format themselves based on a format enum
 - State can have an optional `Label` component, instead of using the entity name
