### PR TITLE
refactor(stat): Centrally registered stats

### DIFF
--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -37,7 +37,9 @@ RocketModule::RocketModule(flecs::world &world) {
       .member("launchpad", &LaunchScheduleAction::launchpad);
   world.component<Rocket>()
       .member("failure_rate", &Rocket::failure_rate)
-      .member("cost", &Rocket::cost);
+      .member("cost", &Rocket::cost)
+      .member("rollout_days", &Rocket::rollout_days)
+      .member("move_days", &Rocket::move_days);
 
   world.component<RocketStateTransitionBlocked>().member(
       "reason", &RocketStateTransitionBlocked::reason);
@@ -85,7 +87,9 @@ RocketModule::RocketModule(flecs::world &world) {
   register_component_lua<Rocket>(
       world, "Rocket", [](LuaFieldBuilder<Rocket> &b) {
         b.nested<&Rocket::failure_rate>({"failure_rate"}, {"Stat"})
-            .nested<&Rocket::cost>({"cost"}, {"Stat"});
+            .nested<&Rocket::cost>({"cost"}, {"Stat"})
+            .nested<&Rocket::rollout_days>({"rollout_days"}, {"Stat"})
+            .nested<&Rocket::move_days>({"move_days"}, {"Stat"});
       });
   register_component_lua<RocketCurrentState>(
       world, "RocketCurrentState",
@@ -214,13 +218,6 @@ RocketModule::RocketModule(flecs::world &world) {
       .without<DurationRequired>()
       .kind(UpdatePhase)
       .each(systemAutoGoForLaunch);
-
-  world.system<Rocket>("Refresh Rocket Stats")
-      .tick_source(sim.speed)
-      .kind(UpdatePhase)
-      .each([](flecs::entity rocketE, Rocket &rocket) {
-        statsApplyModifiers(rocketE, &rocket.failure_rate);
-      });
 }
 
 void systemCreateRocketBuildCategory(flecs::iter &it) {

--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -40,28 +40,28 @@ RocketModule::RocketModule(flecs::world &world) {
       .member("cost", &Rocket::cost)
       .member("rollout_days", &Rocket::rollout_days)
       .member("move_days", &Rocket::move_days);
-  registerStatDef(world, {.id = "failure-rate",
-                          .display = "Failure Rate",
-                          .description =
-                              "Likelyhood the rocket will fail on take-off",
-                          .higher_is_better = false,
-                          .format = Stat::Format::Percentage});
+  registerStatDef(world,
+                  {.id = "failure-rate",
+                   .display = "Failure Rate",
+                   .description = "Likelihood the rocket will fail on take-off",
+                   .higher_is_better = false,
+                   .format = Stat::Format::Percentage});
   registerStatDef(world, {.id = "cost",
                           .display = "Cost",
                           .description = "Cost to build this rocket",
                           .higher_is_better = false,
                           .format = Stat::Format::Currency});
-  registerStatDef(world,
-                  {.id = "rollout-days",
-                   .display = "Rollout Duration",
-                   .description =
-                       "Days to move the rocket from storage to the launchpad",
-                   .higher_is_better = false});
-  registerStatDef(world, {.id = "move-days",
-                          .display = "Move Duration",
-                          .description =
-                              "Days to move the rocket from storage to storage",
-                          .higher_is_better = false});
+  registerStatDef(
+      world,
+      {.id = "rollout-days",
+       .display = "Rollout Duration",
+       .description = "Days to move the rocket from storage to the launchpad",
+       .higher_is_better = false});
+  registerStatDef(
+      world, {.id = "move-days",
+              .display = "Move Duration",
+              .description = "Days to move the rocket from storage to storage",
+              .higher_is_better = false});
 
   world.component<RocketStateTransitionBlocked>().member(
       "reason", &RocketStateTransitionBlocked::reason);

--- a/src/modules/rocket/rocket_module.cpp
+++ b/src/modules/rocket/rocket_module.cpp
@@ -40,6 +40,28 @@ RocketModule::RocketModule(flecs::world &world) {
       .member("cost", &Rocket::cost)
       .member("rollout_days", &Rocket::rollout_days)
       .member("move_days", &Rocket::move_days);
+  registerStatDef(world, {.id = "failure-rate",
+                          .display = "Failure Rate",
+                          .description =
+                              "Likelyhood the rocket will fail on take-off",
+                          .higher_is_better = false,
+                          .format = Stat::Format::Percentage});
+  registerStatDef(world, {.id = "cost",
+                          .display = "Cost",
+                          .description = "Cost to build this rocket",
+                          .higher_is_better = false,
+                          .format = Stat::Format::Currency});
+  registerStatDef(world,
+                  {.id = "rollout-days",
+                   .display = "Rollout Duration",
+                   .description =
+                       "Days to move the rocket from storage to the launchpad",
+                   .higher_is_better = false});
+  registerStatDef(world, {.id = "move-days",
+                          .display = "Move Duration",
+                          .description =
+                              "Days to move the rocket from storage to storage",
+                          .higher_is_better = false});
 
   world.component<RocketStateTransitionBlocked>().member(
       "reason", &RocketStateTransitionBlocked::reason);

--- a/src/modules/rocket/rocket_module.h
+++ b/src/modules/rocket/rocket_module.h
@@ -27,12 +27,10 @@ struct LaunchPlanTargetState {};
 /// @brief Component to indicate entity is a rocket.
 struct Rocket {
   static uint32_t max_id;
-  Stat failure_rate =
-      Stat({.id = "failure-rate", .base = 0.1});
+  Stat failure_rate = Stat({.id = "failure-rate", .base = 0.1});
   Stat cost = Stat({.id = "cost", .base = 5'000'000});
   Stat rollout_days = Stat({.id = "rollout-days", .base = 3});
-  Stat move_days =
-      Stat({.id = "move-days", .base = 1});
+  Stat move_days = Stat({.id = "move-days", .base = 1});
 };
 
 struct RocketCurrentState {};

--- a/src/modules/rocket/rocket_module.h
+++ b/src/modules/rocket/rocket_module.h
@@ -28,30 +28,11 @@ struct LaunchPlanTargetState {};
 struct Rocket {
   static uint32_t max_id;
   Stat failure_rate =
-      Stat({.id = "failure-rate",
-            .display = "Failure Rate",
-            .description = "Likelyhood the rocket will fail on take-off",
-            .base = 0.1,
-            .higher_is_better = false,
-            .format = Stat::Format::Percentage});
-  Stat cost = Stat({.id = "cost",
-                    .display = "Cost",
-                    .description = "Cost to build this rocket",
-                    .base = 5'000'000,
-                    .higher_is_better = false,
-                    .format = Stat::Format::Currency});
-  Stat rollout_days = Stat(
-      {.id = "rollout-days",
-       .display = "Rollout Duration",
-       .description = "Days to move the rocket from storage to the launchpad",
-       .base = 3,
-       .higher_is_better = false});
+      Stat({.id = "failure-rate", .base = 0.1});
+  Stat cost = Stat({.id = "cost", .base = 5'000'000});
+  Stat rollout_days = Stat({.id = "rollout-days", .base = 3});
   Stat move_days =
-      Stat({.id = "move-days",
-            .display = "Move Duration",
-            .description = "Days to move the rocket from storage to storage",
-            .base = 1,
-            .higher_is_better = false});
+      Stat({.id = "move-days", .base = 1});
 };
 
 struct RocketCurrentState {};

--- a/src/modules/site/rocket_prefab_window.cpp
+++ b/src/modules/site/rocket_prefab_window.cpp
@@ -2,7 +2,6 @@
 #include "imgui.h"
 #include "modules/base/assert.h"
 #include "modules/engine/gui.h"
-#include "modules/engine/helpers.h"
 #include "modules/rocket/rocket_actions.h"
 #include "modules/rocket/rocket_module.h"
 #include "modules/simulation/simulation.h"
@@ -112,7 +111,7 @@ void drawRocketPrefabWindow(flecs::entity winE) {
 
     ImGui::Text("%s", prefabE.name().c_str());
     ImGui::TextDisabled("Low Earth Orbit: %s kg", maxMassText.c_str());
-    Widgets::StatTooltip(&cost);
+    Widgets::StatTooltip(world, &cost);
 
     RocketBuildAction action{PrefabEntity{prefabE}, LineEntity{manufacturingE},
                              rocketCost};

--- a/src/modules/site/site.cpp
+++ b/src/modules/site/site.cpp
@@ -65,15 +65,15 @@ SiteModule::SiteModule(flecs::world &world) {
                           .description =
                               "The maximum number of desks this facility can "
                               "hold"});
-  registerStatDef(world, {.id = "max-weight",
-                          .display = "Max Weight",
-                          .description =
-                              "The maximum weight the pad can support"});
-  registerStatDef(world, {.id = "prep-days",
-                          .display = "Prep Days",
-                          .description =
-                              "Number of days required to prepare a launch",
-                          .higher_is_better = false});
+  registerStatDef(world,
+                  {.id = "max-weight",
+                   .display = "Max Weight",
+                   .description = "The maximum weight the pad can support"});
+  registerStatDef(world,
+                  {.id = "prep-days",
+                   .display = "Prep Days",
+                   .description = "Number of days required to prepare a launch",
+                   .higher_is_better = false});
   world.component<BuildingDetailWindow>().member(
       "buildingE", &BuildingDetailWindow::buildingE);
   world.component<ConstructionSiteWindow>().member(

--- a/src/modules/site/site.cpp
+++ b/src/modules/site/site.cpp
@@ -135,13 +135,6 @@ SiteModule::SiteModule(flecs::world &world) {
       .kind(ValidatePhase)
       .each(systemUpdateConstructionSiteLocations);
 
-  world.system<Launchpad>()
-      .kind(UpdatePhase)
-      .each([](flecs::entity e, Launchpad &pad) {
-        statsApplyModifiers(e, &pad.max_weight);
-        statsApplyModifiers(e, &pad.prep_days);
-      });
-
   initWeather(world);
 
   world.system<const Site, const Transform>("Draw Site Border")

--- a/src/modules/site/site.cpp
+++ b/src/modules/site/site.cpp
@@ -60,6 +60,20 @@ SiteModule::SiteModule(flecs::world &world) {
   world.component<Launchpad>()
       .member("max_weight", &Launchpad::max_weight)
       .member("prep_days", &Launchpad::prep_days);
+  registerStatDef(world, {.id = "max-desks",
+                          .display = "Max Desks",
+                          .description =
+                              "The maximum number of desks this facility can "
+                              "hold"});
+  registerStatDef(world, {.id = "max-weight",
+                          .display = "Max Weight",
+                          .description =
+                              "The maximum weight the pad can support"});
+  registerStatDef(world, {.id = "prep-days",
+                          .display = "Prep Days",
+                          .description =
+                              "Number of days required to prepare a launch",
+                          .higher_is_better = false});
   world.component<BuildingDetailWindow>().member(
       "buildingE", &BuildingDetailWindow::buildingE);
   world.component<ConstructionSiteWindow>().member(

--- a/src/modules/site/site.h
+++ b/src/modules/site/site.h
@@ -52,25 +52,15 @@ struct Storage {
 
 struct Office {
   Stat max_desks =
-      Stat({.id = "max-desks",
-            .display = "Max Desks",
-            .description = "The maximum number of desks this facility can hold",
-            .base = 100});
+      Stat({.id = "max-desks", .base = 100});
 };
 
 /// @brief Can launch rockets
 struct Launchpad {
   Stat max_weight =
-      Stat({.id = "max-weight",
-            .display = "Max Weight",
-            .description = "The maximum weight the pad can support",
-            .base = 1000});
+      Stat({.id = "max-weight", .base = 1000});
   Stat prep_days =
-      Stat({.id = "prep-days",
-            .display = "Prep Days",
-            .description = "Number of days required to prepare a launch",
-            .base = 5,
-            .higher_is_better = false});
+      Stat({.id = "prep-days", .base = 5});
 };
 
 /// @brief Indiciates the entity is a future building location

--- a/src/modules/site/site.h
+++ b/src/modules/site/site.h
@@ -51,16 +51,13 @@ struct Storage {
 };
 
 struct Office {
-  Stat max_desks =
-      Stat({.id = "max-desks", .base = 100});
+  Stat max_desks = Stat({.id = "max-desks", .base = 100});
 };
 
 /// @brief Can launch rockets
 struct Launchpad {
-  Stat max_weight =
-      Stat({.id = "max-weight", .base = 1000});
-  Stat prep_days =
-      Stat({.id = "prep-days", .base = 5});
+  Stat max_weight = Stat({.id = "max-weight", .base = 1000});
+  Stat prep_days = Stat({.id = "prep-days", .base = 5});
 };
 
 /// @brief Indiciates the entity is a future building location

--- a/src/modules/staff/staff.cpp
+++ b/src/modules/staff/staff.cpp
@@ -16,18 +16,18 @@ StaffModule::StaffModule(flecs::world &world) {
       .member("domain_skill", &Employee::domain_skill)
       .member("leadership_skill", &Employee::leadership_skill)
       .member("motivation", &Employee::motivation);
-  registerStatDef(world, {.id = "motivation",
-                          .display = "Motivation",
-                          .description =
-                              "How well motivated this employee is"});
-  registerStatDef(world, {.id = "leadership_skill",
-                          .display = "Leadership Skills",
-                          .description =
-                              "How good this person is at leading others"});
-  registerStatDef(world, {.id = "domains_skills",
-                          .display = "Domain Skills",
-                          .description =
-                              "How good this person is at their job"});
+  registerStatDef(world,
+                  {.id = "motivation",
+                   .display = "Motivation",
+                   .description = "How well motivated this employee is"});
+  registerStatDef(world,
+                  {.id = "leadership_skill",
+                   .display = "Leadership Skills",
+                   .description = "How good this person is at leading others"});
+  registerStatDef(world,
+                  {.id = "domains_skills",
+                   .display = "Domain Skills",
+                   .description = "How good this person is at their job"});
 
   world.component<Team>().member("name", &Team::name);
 

--- a/src/modules/staff/staff.cpp
+++ b/src/modules/staff/staff.cpp
@@ -4,6 +4,8 @@
 void systemSeedStaff(flecs::iter &it);
 
 StaffModule::StaffModule(flecs::world &world) {
+  world.import <StatsModule>();
+
   // Register components
   world.component<Person>()
       .member("first_name", &Person::first_name)
@@ -14,6 +16,18 @@ StaffModule::StaffModule(flecs::world &world) {
       .member("domain_skill", &Employee::domain_skill)
       .member("leadership_skill", &Employee::leadership_skill)
       .member("motivation", &Employee::motivation);
+  registerStatDef(world, {.id = "motivation",
+                          .display = "Motivation",
+                          .description =
+                              "How well motivated this employee is"});
+  registerStatDef(world, {.id = "leadership_skill",
+                          .display = "Leadership Skills",
+                          .description =
+                              "How good this person is at leading others"});
+  registerStatDef(world, {.id = "domains_skills",
+                          .display = "Domain Skills",
+                          .description =
+                              "How good this person is at their job"});
 
   world.component<Team>().member("name", &Team::name);
 

--- a/src/modules/staff/staff.h
+++ b/src/modules/staff/staff.h
@@ -13,18 +13,9 @@ struct Person {
 /// @brief An Employee of the company
 struct Employee {
   int start = 0;
-  Stat motivation = Stat({.id = "motivation",
-                          .display = "Motivation",
-                          .description = "How well motivated this employee is",
-                          .base = 50.0});
-  Stat leadership_skill =
-      Stat({.id = "leadership_skill",
-            .display = "Leadership Skills",
-            .description = "How good this person is at leading others"});
-  Stat domain_skill =
-      Stat({.id = "domains_skills",
-            .display = "Domain Skills",
-            .description = "How good this person is at their job"});
+  Stat motivation = Stat({.id = "motivation", .base = 50.0});
+  Stat leadership_skill = Stat({.id = "leadership_skill"});
+  Stat domain_skill = Stat({.id = "domains_skills"});
 };
 
 /// @brief A team in the company

--- a/src/modules/stats/stats.cpp
+++ b/src/modules/stats/stats.cpp
@@ -75,16 +75,14 @@ StatsModule::StatsModule(flecs::world &world) {
         .value("Currency", StatDef::Format::Currency)
         .value("Percentage", StatDef::Format::Percentage);
   });
-  register_component_lua<StatDef>(world, "StatDef",
-                                  [](LuaFieldBuilder<StatDef> &b) {
-                                    b.field<&StatDef::id>("id")
-                                        .field<&StatDef::display>("display")
-                                        .field<&StatDef::description>(
-                                            "description")
-                                        .field<&StatDef::higher_is_better>(
-                                            "higher_is_better")
-                                        .field<&StatDef::format>("format");
-                                  });
+  register_component_lua<StatDef>(
+      world, "StatDef", [](LuaFieldBuilder<StatDef> &b) {
+        b.field<&StatDef::id>("id")
+            .field<&StatDef::display>("display")
+            .field<&StatDef::description>("description")
+            .field<&StatDef::higher_is_better>("higher_is_better")
+            .field<&StatDef::format>("format");
+      });
 
   register_component_lua<Effect>(world, "Effect");
 
@@ -183,29 +181,28 @@ void discoverStatComponents(flecs::world &world) {
   auto &registry = world.ensure<StatRegistry>();
   const flecs::id_t stat_id = world.component<Stat>().id();
 
-  world.query<const EcsStruct>().each(
-      [&](flecs::entity component, const EcsStruct &metadata) {
-        std::vector<int32_t> offsets;
-        const int32_t count = ecs_vec_count(&metadata.members);
-        offsets.reserve(static_cast<size_t>(count));
+  world.query<const EcsStruct>().each([&](flecs::entity component,
+                                          const EcsStruct &metadata) {
+    std::vector<int32_t> offsets;
+    const int32_t count = ecs_vec_count(&metadata.members);
+    offsets.reserve(static_cast<size_t>(count));
 
-        for (int32_t i = 0; i < count; ++i) {
-          const auto *member =
-              ecs_vec_get_t(&metadata.members, ecs_member_t, i);
-          if (member->type == stat_id) {
-            offsets.push_back(member->offset);
-          }
-        }
+    for (int32_t i = 0; i < count; ++i) {
+      const auto *member = ecs_vec_get_t(&metadata.members, ecs_member_t, i);
+      if (member->type == stat_id) {
+        offsets.push_back(member->offset);
+      }
+    }
 
-        if (offsets.empty()) {
-          return;
-        }
+    if (offsets.empty()) {
+      return;
+    }
 
-        std::ranges::sort(offsets);
-        auto &entry = registry.components[component.id()];
-        entry.component_id = component.id();
-        entry.offsets = std::move(offsets);
-      });
+    std::ranges::sort(offsets);
+    auto &entry = registry.components[component.id()];
+    entry.component_id = component.id();
+    entry.offsets = std::move(offsets);
+  });
 }
 
 void registerStatSystems(flecs::world &world) {

--- a/src/modules/stats/stats.cpp
+++ b/src/modules/stats/stats.cpp
@@ -1,10 +1,37 @@
 #include "stats.h"
 #include "modules/engine/helpers.h"
 #include "modules/lua/lua.h"
+#include <algorithm>
+#include <cstddef>
 #include <format>
 #include <modules/base/base.h>
 
 void systemInitialiseStats(flecs::iter &iter);
+void systemApplyReflectedStats(flecs::iter &iter);
+void systemRegisterReflectedStatSystems(flecs::iter &iter);
+
+namespace {
+
+Stat *statAt(void *component, int32_t offset) {
+  auto *bytes = static_cast<std::byte *>(component);
+  return reinterpret_cast<Stat *>(bytes + offset);
+}
+
+const Stat *statAt(const void *component, int32_t offset) {
+  auto *bytes = static_cast<const std::byte *>(component);
+  return reinterpret_cast<const Stat *>(bytes + offset);
+}
+
+std::string statSystemName(flecs::entity component) {
+  const auto path = component.path();
+  const char *name = path.c_str();
+  if (name[0] != '\0') {
+    return std::format("Apply Stats {}", name);
+  }
+  return std::format("Apply Stats #{}", component.id());
+}
+
+} // namespace
 
 /// @brief Constructor for the StatsModule.
 /// @param[in,out] world The flecs world.
@@ -13,6 +40,8 @@ StatsModule::StatsModule(flecs::world &world) {
   world.import <BaseModule>();
 
   // Register components
+  world.component<StatRegistry>().add(flecs::Singleton);
+  world.set<StatRegistry>({});
   world.component<Stat>("Stat")
       .member("id", &Stat::m_id)
       .member("display", &Stat::m_display)
@@ -48,7 +77,10 @@ StatsModule::StatsModule(flecs::world &world) {
   world.entity("Effects");
   world.set(s);
 
-  // Register systems
+  world.system("Register Reflected Stat Systems")
+      .kind(flecs::OnStart)
+      .immediate()
+      .run(systemRegisterReflectedStatSystems);
 }
 
 double Stat::base() const { return m_base; }
@@ -125,4 +157,117 @@ void applyModifiers(flecs::entity e, std::vector<Stat *> &stats) {
 void statsApplyModifiers(flecs::entity e, Stat *stat) {
   auto vec = std::vector<Stat *>{stat};
   applyModifiers(e, vec);
+}
+
+void discoverStatComponents(flecs::world &world) {
+  auto &registry = world.ensure<StatRegistry>();
+  const flecs::id_t stat_id = world.component<Stat>().id();
+
+  world.query<const EcsStruct>().each(
+      [&](flecs::entity component, const EcsStruct &metadata) {
+        std::vector<int32_t> offsets;
+        const int32_t count = ecs_vec_count(&metadata.members);
+        offsets.reserve(static_cast<size_t>(count));
+
+        for (int32_t i = 0; i < count; ++i) {
+          const auto *member =
+              ecs_vec_get_t(&metadata.members, ecs_member_t, i);
+          if (member->type == stat_id) {
+            offsets.push_back(member->offset);
+          }
+        }
+
+        if (offsets.empty()) {
+          return;
+        }
+
+        std::ranges::sort(offsets);
+        auto &entry = registry.components[component.id()];
+        entry.component_id = component.id();
+        entry.offsets = std::move(offsets);
+      });
+}
+
+void registerStatSystems(flecs::world &world) {
+  discoverStatComponents(world);
+  auto &registry = world.ensure<StatRegistry>();
+
+  for (auto &[component_id, entry] : registry.components) {
+    if (entry.system_registered) {
+      continue;
+    }
+
+    auto component = world.entity(component_id);
+    const auto name = statSystemName(component);
+    world.system(name.c_str())
+        .with(component_id)
+        .kind(UpdatePhase)
+        .run(systemApplyReflectedStats);
+    entry.system_registered = true;
+  }
+}
+
+Stat *findStat(flecs::entity e, std::string_view id) {
+  if (!e.is_valid()) {
+    return nullptr;
+  }
+
+  auto world = e.world();
+  const auto *registry = world.try_get<StatRegistry>();
+  if (!registry) {
+    return nullptr;
+  }
+
+  for (const auto &[component_id, entry] : registry->components) {
+    const void *component = e.try_get(component_id);
+    if (!component) {
+      continue;
+    }
+
+    for (const auto offset : entry.offsets) {
+      auto *stat = const_cast<Stat *>(statAt(component, offset));
+      if (stat->id() == id) {
+        return stat;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+void systemApplyReflectedStats(flecs::iter &iter) {
+  auto world = iter.world();
+  auto *registry = world.try_get<StatRegistry>();
+  if (!registry) {
+    return;
+  }
+
+  std::vector<Stat *> stats;
+
+  while (iter.next()) {
+    const flecs::id_t component_id = ecs_field_id(iter.c_ptr(), 0);
+    const auto entry_it = registry->components.find(component_id);
+    if (entry_it == registry->components.end()) {
+      continue;
+    }
+
+    const auto &offsets = entry_it->second.offsets;
+    stats.reserve(offsets.size());
+
+    for (auto row : iter) {
+      auto *component = iter.field_at(0, row);
+      stats.clear();
+
+      for (const auto offset : offsets) {
+        stats.push_back(statAt(component, offset));
+      }
+
+      applyModifiers(iter.entity(row), stats);
+    }
+  }
+}
+
+void systemRegisterReflectedStatSystems(flecs::iter &iter) {
+  auto world = iter.world();
+  registerStatSystems(world);
 }

--- a/src/modules/stats/stats.cpp
+++ b/src/modules/stats/stats.cpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <format>
 #include <modules/base/base.h>
+#include <utility>
 
 void systemInitialiseStats(flecs::iter &iter);
 void systemApplyReflectedStats(flecs::iter &iter);
@@ -42,10 +43,18 @@ StatsModule::StatsModule(flecs::world &world) {
   // Register components
   world.component<StatRegistry>().add(flecs::Singleton);
   world.set<StatRegistry>({});
+  world.component<StatDef::Format>("StatFormat")
+      .constant("Number", StatDef::Format::Number)
+      .constant("Currency", StatDef::Format::Currency)
+      .constant("Percentage", StatDef::Format::Percentage);
+  world.component<StatDef>("StatDef")
+      .member("id", &StatDef::id)
+      .member("display", &StatDef::display)
+      .member("description", &StatDef::description)
+      .member("higher_is_better", &StatDef::higher_is_better)
+      .member("format", &StatDef::format);
   world.component<Stat>("Stat")
       .member("id", &Stat::m_id)
-      .member("display", &Stat::m_display)
-      .member("description", &Stat::m_description)
       .member("base", &Stat::m_base);
   world.component<Effect>();
   world.component<HasEffect>();
@@ -59,10 +68,23 @@ StatsModule::StatsModule(flecs::world &world) {
     b.computed<[](const Stat *s) { return s->base(); },
                [](Stat *s, double v) { s->setBase(v); }>("base")
         .getter<[](const Stat *s) { return s->value(); }>("value")
-        .getter<[](const Stat *s) { return s->id(); }>("id")
-        .getter<[](const Stat *s) { return s->display(); }>("display")
-        .getter<[](const Stat *s) { return s->description(); }>("description");
+        .getter<[](const Stat *s) { return s->id(); }>("id");
   });
+  register_enum_table_lua(world, "StatFormat", [](LuaEnumBuilder &b) {
+    b.value("Number", StatDef::Format::Number)
+        .value("Currency", StatDef::Format::Currency)
+        .value("Percentage", StatDef::Format::Percentage);
+  });
+  register_component_lua<StatDef>(world, "StatDef",
+                                  [](LuaFieldBuilder<StatDef> &b) {
+                                    b.field<&StatDef::id>("id")
+                                        .field<&StatDef::display>("display")
+                                        .field<&StatDef::description>(
+                                            "description")
+                                        .field<&StatDef::higher_is_better>(
+                                            "higher_is_better")
+                                        .field<&StatDef::format>("format");
+                                  });
 
   register_component_lua<Effect>(world, "Effect");
 
@@ -97,14 +119,12 @@ void Stat::reset() {
 }
 
 const std::string &Stat::id() const { return m_id; }
-const std::string &Stat::display() const { return m_display; }
-const std::string &Stat::description() const { return m_description; }
 const std::vector<EffectModifier> &Stat::modifiers() const {
   return m_modifiers;
 }
 
-std::string Stat::format(double value) const {
-  switch (m_format) {
+std::string StatDef::formatValue(double value) const {
+  switch (format) {
   case Format::Currency:
     return "$" + format_locale(value);
   case Format::Percentage:
@@ -207,6 +227,40 @@ void registerStatSystems(flecs::world &world) {
   }
 }
 
+void registerStatDef(flecs::world &world, StatDef definition) {
+  if (definition.id.empty()) {
+    return;
+  }
+  if (definition.display.empty()) {
+    definition.display = definition.id;
+  }
+
+  auto &registry = world.ensure<StatRegistry>();
+  registry.definitions.insert_or_assign(definition.id, std::move(definition));
+}
+
+const StatDef *findStatDef(flecs::world &world, std::string_view id) {
+  const auto *registry = world.try_get<StatRegistry>();
+  if (!registry) {
+    return nullptr;
+  }
+
+  const auto it = registry->definitions.find(std::string(id));
+  if (it == registry->definitions.end()) {
+    return nullptr;
+  }
+  return &it->second;
+}
+
+StatDef statDef(flecs::world &world, std::string_view id) {
+  if (const auto *definition = findStatDef(world, id)) {
+    return *definition;
+  }
+
+  const auto fallback = std::string(id);
+  return {.id = fallback, .display = fallback, .description = {}};
+}
+
 Stat *findStat(flecs::entity e, std::string_view id) {
   if (!e.is_valid()) {
     return nullptr;
@@ -237,17 +291,14 @@ Stat *findStat(flecs::entity e, std::string_view id) {
 
 void systemApplyReflectedStats(flecs::iter &iter) {
   auto world = iter.world();
-  auto *registry = world.try_get<StatRegistry>();
-  if (!registry) {
-    return;
-  }
+  auto &registry = world.ensure<StatRegistry>();
 
   std::vector<Stat *> stats;
 
   while (iter.next()) {
     const flecs::id_t component_id = ecs_field_id(iter.c_ptr(), 0);
-    const auto entry_it = registry->components.find(component_id);
-    if (entry_it == registry->components.end()) {
+    const auto entry_it = registry.components.find(component_id);
+    if (entry_it == registry.components.end()) {
       continue;
     }
 
@@ -259,7 +310,8 @@ void systemApplyReflectedStats(flecs::iter &iter) {
       stats.clear();
 
       for (const auto offset : offsets) {
-        stats.push_back(statAt(component, offset));
+        auto *stat = statAt(component, offset);
+        stats.push_back(stat);
       }
 
       applyModifiers(iter.entity(row), stats);

--- a/src/modules/stats/stats.h
+++ b/src/modules/stats/stats.h
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <flecs.h>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 /// Represents an effect in the system.
@@ -111,6 +112,28 @@ void applyModifiers(flecs::entity e, std::vector<Stat *> &stats);
 /// @param e The entity.
 /// @param stat The stat to apply modifiers to.
 void statsApplyModifiers(flecs::entity e, Stat *stat);
+
+struct StatComponentRegistration {
+  flecs::id_t component_id = 0;
+  std::vector<int32_t> offsets;
+  bool system_registered = false;
+};
+
+struct StatRegistry {
+  std::unordered_map<flecs::id_t, StatComponentRegistration> components;
+};
+
+/// Discovers reflected component members whose type is Stat.
+void discoverStatComponents(flecs::world &world);
+
+/// Registers automatic modifier application systems for discovered stats.
+void registerStatSystems(flecs::world &world);
+
+/// Finds a reflected Stat by id on an entity.
+///
+/// The returned pointer is into ECS component storage. Use it immediately and do
+/// not store it across ECS mutations or progress calls.
+[[nodiscard]] Stat *findStat(flecs::entity e, std::string_view id);
 
 /// Represents the stats module.
 struct StatsModule {

--- a/src/modules/stats/stats.h
+++ b/src/modules/stats/stats.h
@@ -24,29 +24,33 @@ struct EffectModifier {
   std::string effectName; ///< The name of the effect.
 };
 
-struct StatInit {
+struct StatDef {
   std::string id;
   std::string display;
   std::string description;
-  double base = 0.0;
   bool higher_is_better = true;
   enum class Format : std::uint8_t {
     Number,
     Currency,
     Percentage
   } format = Format::Number;
+
+  [[nodiscard]] std::string formatValue(double value) const;
+};
+
+struct StatInit {
+  std::string id;
+  double base = 0.0;
 };
 
 /// Represents a modifiable stat.
 class Stat {
 public:
-  using Format = StatInit::Format;
+  using Format = StatDef::Format;
 
   Stat() = default;
   explicit Stat(const StatInit &init)
-      : m_id(init.id), m_display(init.display), m_description(init.description),
-        m_base(init.base), higher_is_better(init.higher_is_better),
-        m_format(init.format) {}
+      : m_id(init.id), m_base(init.base) {}
 
   /// Gets the base value of the stat.
   /// @return The base value.
@@ -71,36 +75,17 @@ public:
   /// @return The ID.
   [[nodiscard]] const std::string &id() const;
 
-  /// Gets the display name of the stat.
-  /// @return The display name.
-  [[nodiscard]] const std::string &display() const;
-
-  /// Gets the description of the stat.
-  /// @return The description.
-  [[nodiscard]] const std::string &description() const;
-
   /// Gets the list of modifiers applied to the stat.
   /// @return The list of modifiers.
   [[nodiscard]] const std::vector<EffectModifier> &modifiers() const;
 
-  /// Formats a value according to this stat's display type.
-  [[nodiscard]] std::string format(double value) const;
-
-  /// @brief Checks if higher values of the stat are better.
-  /// @return True if higher values are better, false otherwise.
-  [[nodiscard]] bool isHigherBetter() const { return higher_is_better; }
-
 public:
   std::string m_id;                        ///< The ID of the stat.
-  std::string m_display;                   ///< The display name of the stat.
-  std::string m_description;               ///< The description of the stat.
   std::vector<EffectModifier> m_modifiers; ///< The list of modifiers.
   double m_base = 0.0f;                    ///< The base value of the stat.
   double m_additive_modifiers = 0.0f;      ///< The total additive modifiers.
   double m_multiplicative_modifiers =
       1.0f;                     ///< The total multiplicative modifiers.
-  bool higher_is_better = true; ///< Indicates if higher values are better.
-  Format m_format = Format::Number;
 };
 
 /// Applies modifiers to the stats of an entity.
@@ -121,7 +106,21 @@ struct StatComponentRegistration {
 
 struct StatRegistry {
   std::unordered_map<flecs::id_t, StatComponentRegistration> components;
+  std::unordered_map<std::string, StatDef> definitions;
 };
+
+/// Registers display metadata for a stat id.
+void registerStatDef(flecs::world &world, StatDef definition);
+
+/// Finds display metadata for a stat id.
+[[nodiscard]] const StatDef *findStatDef(flecs::world &world,
+                                         std::string_view id);
+
+/// Gets display metadata for a stat id.
+///
+/// Unknown ids are represented with a default definition that uses the id as
+/// its display name.
+[[nodiscard]] StatDef statDef(flecs::world &world, std::string_view id);
 
 /// Discovers reflected component members whose type is Stat.
 void discoverStatComponents(flecs::world &world);

--- a/src/modules/stats/stats.h
+++ b/src/modules/stats/stats.h
@@ -49,8 +49,7 @@ public:
   using Format = StatDef::Format;
 
   Stat() = default;
-  explicit Stat(const StatInit &init)
-      : m_id(init.id), m_base(init.base) {}
+  explicit Stat(const StatInit &init) : m_id(init.id), m_base(init.base) {}
 
   /// Gets the base value of the stat.
   /// @return The base value.
@@ -85,7 +84,7 @@ public:
   double m_base = 0.0f;                    ///< The base value of the stat.
   double m_additive_modifiers = 0.0f;      ///< The total additive modifiers.
   double m_multiplicative_modifiers =
-      1.0f;                     ///< The total multiplicative modifiers.
+      1.0f; ///< The total multiplicative modifiers.
 };
 
 /// Applies modifiers to the stats of an entity.
@@ -130,8 +129,8 @@ void registerStatSystems(flecs::world &world);
 
 /// Finds a reflected Stat by id on an entity.
 ///
-/// The returned pointer is into ECS component storage. Use it immediately and do
-/// not store it across ECS mutations or progress calls.
+/// The returned pointer is into ECS component storage. Use it immediately and
+/// do not store it across ECS mutations or progress calls.
 [[nodiscard]] Stat *findStat(flecs::entity e, std::string_view id);
 
 /// Represents the stats module.

--- a/src/modules/window/building_detail_window.cpp
+++ b/src/modules/window/building_detail_window.cpp
@@ -186,8 +186,8 @@ void drawLaunchpadSection(flecs::entity &entity) {
   auto world = entity.world();
 
   const auto &launchpad = entity.get<Launchpad>();
-  Widgets::StatTooltip(&launchpad.max_weight);
-  Widgets::StatTooltip(&launchpad.prep_days);
+  Widgets::StatTooltip(world, &launchpad.max_weight);
+  Widgets::StatTooltip(world, &launchpad.prep_days);
 
   ImGui::Separator();
   flecs::query<LaunchPlan> query =

--- a/src/modules/window/rocket_detail_window.cpp
+++ b/src/modules/window/rocket_detail_window.cpp
@@ -178,10 +178,10 @@ void drawRocketDetailWindow(flecs::entity winE) {
     ImGui::TableSetColumnIndex(1);
 
     ImGui::TextDisabled("Stats");
-    Widgets::StatTooltip(&rocketData.failure_rate);
-    Widgets::StatTooltip(&rocketData.cost);
-    Widgets::StatTooltip(&rocketData.rollout_days);
-    Widgets::StatTooltip(&rocketData.move_days);
+    Widgets::StatTooltip(world, &rocketData.failure_rate);
+    Widgets::StatTooltip(world, &rocketData.cost);
+    Widgets::StatTooltip(world, &rocketData.rollout_days);
+    Widgets::StatTooltip(world, &rocketData.move_days);
 
     ImGui::EndTable();
   }

--- a/src/widgets/stat_widget.cpp
+++ b/src/widgets/stat_widget.cpp
@@ -7,9 +7,9 @@ namespace Widgets {
 namespace {
 
 ImVec4 modifierColour(const Modifier &mod, const StatDef &definition) {
-  constexpr ImVec4 red = ImVec4(1.0, 0.0, 0.0, 1.0);
-  constexpr ImVec4 green = ImVec4(0.0, 0.5, 0.0, 1.0);
-  constexpr ImVec4 neutral = ImVec4(0.7, 0.7, 0.7, 1.0);
+  constexpr ImVec4 red = ImVec4(1.0f, 0.0f, 0.0f, 1.0f);
+  constexpr ImVec4 green = ImVec4(0.0f, 0.5f, 0.0f, 1.0f);
+  constexpr ImVec4 neutral = ImVec4(0.7f, 0.7f, 0.7f, 1.0f);
 
   if (mod.additive > 0.0 || mod.multiplicative > 1.0) {
     return definition.higher_is_better ? green : red;

--- a/src/widgets/stat_widget.cpp
+++ b/src/widgets/stat_widget.cpp
@@ -22,8 +22,7 @@ ImVec4 modifierColour(const Modifier &mod, const StatDef &definition) {
 
 } // namespace
 
-std::string ModifierValueText(const Modifier &mod,
-                              const StatDef &definition) {
+std::string ModifierValueText(const Modifier &mod, const StatDef &definition) {
   if (mod.additive > 0.0) {
     return "+" + definition.formatValue(mod.additive);
   }
@@ -48,8 +47,7 @@ bool ModifierLine(const char *label, const Modifier &mod,
 
   ImGui::Text("%s:", label);
   ImGui::SameLine();
-  ImGui::TextColored(modifierColour(mod, definition), "%s",
-                     modValue.c_str());
+  ImGui::TextColored(modifierColour(mod, definition), "%s", modValue.c_str());
   return true;
 }
 
@@ -61,8 +59,7 @@ void StatTooltip(flecs::world &world, const Stat *stat) {
   if (ImGui::BeginItemTooltip()) {
     ImGui::Text("%s", definition.description.c_str());
     ImGui::Separator();
-    ImGui::Text("Base Value: %s",
-                definition.formatValue(stat->base()).c_str());
+    ImGui::Text("Base Value: %s", definition.formatValue(stat->base()).c_str());
     for (const auto &item : stat->modifiers()) {
       ModifierLine(item.effectName.c_str(), item.mod, definition);
     }

--- a/src/widgets/stat_widget.cpp
+++ b/src/widgets/stat_widget.cpp
@@ -1,53 +1,34 @@
 #include "stat_widget.h"
 #include "imgui.h"
-#include "modules/engine/helpers.h"
 #include <format>
 
 namespace Widgets {
 
 namespace {
 
-std::string formatModifierValue(double value, Stat::Format format) {
-  switch (format) {
-  case Stat::Format::Currency:
-    return "$" + format_locale(value);
-  case Stat::Format::Percentage:
-    return std::format("{:.0f}%", value * 100);
-  case Stat::Format::Number:
-  default:
-    return std::format("{:.0f}", value);
-  }
-}
-
-ImVec4 modifierColour(const Modifier &mod, const Stat *stat,
-                      ModifierDisplayOptions options) {
+ImVec4 modifierColour(const Modifier &mod, const StatDef &definition) {
   constexpr ImVec4 red = ImVec4(1.0, 0.0, 0.0, 1.0);
   constexpr ImVec4 green = ImVec4(0.0, 0.5, 0.0, 1.0);
   constexpr ImVec4 neutral = ImVec4(0.7, 0.7, 0.7, 1.0);
-  const bool higherIsBetter =
-      stat ? stat->isHigherBetter() : options.fallback_higher_is_better;
 
   if (mod.additive > 0.0 || mod.multiplicative > 1.0) {
-    return higherIsBetter ? green : red;
+    return definition.higher_is_better ? green : red;
   }
   if (mod.additive < 0.0 || mod.multiplicative < 1.0) {
-    return higherIsBetter ? red : green;
+    return definition.higher_is_better ? red : green;
   }
   return neutral;
 }
 
 } // namespace
 
-std::string ModifierValueText(const Modifier &mod, const Stat *stat,
-                              ModifierDisplayOptions options) {
+std::string ModifierValueText(const Modifier &mod,
+                              const StatDef &definition) {
   if (mod.additive > 0.0) {
-    return "+" + (stat ? stat->format(mod.additive)
-                       : formatModifierValue(mod.additive,
-                                             options.fallback_format));
+    return "+" + definition.formatValue(mod.additive);
   }
   if (mod.additive < 0.0) {
-    return stat ? stat->format(mod.additive)
-                : formatModifierValue(mod.additive, options.fallback_format);
+    return definition.formatValue(mod.additive);
   }
   if (mod.multiplicative > 1.0) {
     return std::format("+{:.0f}%", (mod.multiplicative - 1.0) * 100);
@@ -58,33 +39,36 @@ std::string ModifierValueText(const Modifier &mod, const Stat *stat,
   return {};
 }
 
-bool ModifierLine(const char *label, const Modifier &mod, const Stat *stat,
-                  ModifierDisplayOptions options) {
-  const auto modValue = ModifierValueText(mod, stat, options);
+bool ModifierLine(const char *label, const Modifier &mod,
+                  const StatDef &definition) {
+  const auto modValue = ModifierValueText(mod, definition);
   if (modValue.empty()) {
     return false;
   }
 
   ImGui::Text("%s:", label);
   ImGui::SameLine();
-  ImGui::TextColored(modifierColour(mod, stat, options), "%s",
+  ImGui::TextColored(modifierColour(mod, definition), "%s",
                      modValue.c_str());
   return true;
 }
 
-void StatTooltip(const Stat *stat) {
-  ImGui::Text("%s: %s", stat->display().c_str(),
-              stat->format(stat->value()).c_str());
+void StatTooltip(flecs::world &world, const Stat *stat) {
+  const auto definition = statDef(world, stat->id());
+  ImGui::Text("%s: %s", definition.display.c_str(),
+              definition.formatValue(stat->value()).c_str());
 
   if (ImGui::BeginItemTooltip()) {
-    ImGui::Text("%s", stat->description().c_str());
+    ImGui::Text("%s", definition.description.c_str());
     ImGui::Separator();
-    ImGui::Text("Base Value: %s", stat->format(stat->base()).c_str());
+    ImGui::Text("Base Value: %s",
+                definition.formatValue(stat->base()).c_str());
     for (const auto &item : stat->modifiers()) {
-      ModifierLine(item.effectName.c_str(), item.mod, stat);
+      ModifierLine(item.effectName.c_str(), item.mod, definition);
     }
     ImGui::Separator();
-    ImGui::Text("Final Value: %s", stat->format(stat->value()).c_str());
+    ImGui::Text("Final Value: %s",
+                definition.formatValue(stat->value()).c_str());
     ImGui::EndTooltip();
   }
 }

--- a/src/widgets/stat_widget.cpp
+++ b/src/widgets/stat_widget.cpp
@@ -1,8 +1,76 @@
 #include "stat_widget.h"
 #include "imgui.h"
+#include "modules/engine/helpers.h"
 #include <format>
 
 namespace Widgets {
+
+namespace {
+
+std::string formatModifierValue(double value, Stat::Format format) {
+  switch (format) {
+  case Stat::Format::Currency:
+    return "$" + format_locale(value);
+  case Stat::Format::Percentage:
+    return std::format("{:.0f}%", value * 100);
+  case Stat::Format::Number:
+  default:
+    return std::format("{:.0f}", value);
+  }
+}
+
+ImVec4 modifierColour(const Modifier &mod, const Stat *stat,
+                      ModifierDisplayOptions options) {
+  constexpr ImVec4 red = ImVec4(1.0, 0.0, 0.0, 1.0);
+  constexpr ImVec4 green = ImVec4(0.0, 0.5, 0.0, 1.0);
+  constexpr ImVec4 neutral = ImVec4(0.7, 0.7, 0.7, 1.0);
+  const bool higherIsBetter =
+      stat ? stat->isHigherBetter() : options.fallback_higher_is_better;
+
+  if (mod.additive > 0.0 || mod.multiplicative > 1.0) {
+    return higherIsBetter ? green : red;
+  }
+  if (mod.additive < 0.0 || mod.multiplicative < 1.0) {
+    return higherIsBetter ? red : green;
+  }
+  return neutral;
+}
+
+} // namespace
+
+std::string ModifierValueText(const Modifier &mod, const Stat *stat,
+                              ModifierDisplayOptions options) {
+  if (mod.additive > 0.0) {
+    return "+" + (stat ? stat->format(mod.additive)
+                       : formatModifierValue(mod.additive,
+                                             options.fallback_format));
+  }
+  if (mod.additive < 0.0) {
+    return stat ? stat->format(mod.additive)
+                : formatModifierValue(mod.additive, options.fallback_format);
+  }
+  if (mod.multiplicative > 1.0) {
+    return std::format("+{:.0f}%", (mod.multiplicative - 1.0) * 100);
+  }
+  if (mod.multiplicative < 1.0) {
+    return std::format("{:.0f}%", (mod.multiplicative - 1.0) * 100);
+  }
+  return {};
+}
+
+bool ModifierLine(const char *label, const Modifier &mod, const Stat *stat,
+                  ModifierDisplayOptions options) {
+  const auto modValue = ModifierValueText(mod, stat, options);
+  if (modValue.empty()) {
+    return false;
+  }
+
+  ImGui::Text("%s:", label);
+  ImGui::SameLine();
+  ImGui::TextColored(modifierColour(mod, stat, options), "%s",
+                     modValue.c_str());
+  return true;
+}
 
 void StatTooltip(const Stat *stat) {
   ImGui::Text("%s: %s", stat->display().c_str(),
@@ -12,30 +80,8 @@ void StatTooltip(const Stat *stat) {
     ImGui::Text("%s", stat->description().c_str());
     ImGui::Separator();
     ImGui::Text("Base Value: %s", stat->format(stat->base()).c_str());
-    constexpr ImVec4 red = ImVec4(1.0, 0.0, 0.0, 1.0);
-    constexpr ImVec4 green = ImVec4(0.0, 0.5, 0.0, 1.0);
     for (const auto &item : stat->modifiers()) {
-      std::string modValue = "";
-      ImVec4 colour;
-      if (item.mod.additive > 0) {
-        modValue = "+" + stat->format(item.mod.additive);
-        colour = stat->isHigherBetter() ? green : red;
-      } else if (item.mod.additive < 0) {
-        modValue = stat->format(item.mod.additive);
-        colour = stat->isHigherBetter() ? red : green;
-      }
-      if (item.mod.multiplicative > 1) {
-        modValue = std::format("+{:.0f}%", (item.mod.multiplicative - 1) * 100);
-        colour = stat->isHigherBetter() ? green : red;
-      } else if (item.mod.multiplicative < 1) {
-        modValue = std::format("{:.0f}%", (item.mod.multiplicative - 1) * 100);
-        colour = stat->isHigherBetter() ? red : green;
-      }
-      ImGui::Text("%s:", item.effectName.c_str());
-      ImGui::SameLine();
-      if (!modValue.empty()) {
-        ImGui::TextColored(colour, "%s", modValue.c_str());
-      }
+      ModifierLine(item.effectName.c_str(), item.mod, stat);
     }
     ImGui::Separator();
     ImGui::Text("Final Value: %s", stat->format(stat->value()).c_str());

--- a/src/widgets/stat_widget.h
+++ b/src/widgets/stat_widget.h
@@ -4,20 +4,14 @@
 #include <string>
 
 namespace Widgets {
-struct ModifierDisplayOptions {
-  Stat::Format fallback_format = Stat::Format::Number;
-  bool fallback_higher_is_better = true;
-};
 
-[[nodiscard]] std::string ModifierValueText(
-    const Modifier &mod, const Stat *stat = nullptr,
-    ModifierDisplayOptions options = {});
+[[nodiscard]] std::string ModifierValueText(const Modifier &mod,
+                                            const StatDef &definition);
 
 /// Draws a single labeled modifier line. Returns false when there is no visible
 /// modifier value to display.
 bool ModifierLine(const char *label, const Modifier &mod,
-                  const Stat *stat = nullptr,
-                  ModifierDisplayOptions options = {});
+                  const StatDef &definition);
 
-void StatTooltip(const Stat *stat);
+void StatTooltip(flecs::world &world, const Stat *stat);
 } // namespace Widgets

--- a/src/widgets/stat_widget.h
+++ b/src/widgets/stat_widget.h
@@ -1,7 +1,23 @@
 #pragma once
 
 #include "modules/stats/stats.h"
+#include <string>
 
 namespace Widgets {
+struct ModifierDisplayOptions {
+  Stat::Format fallback_format = Stat::Format::Number;
+  bool fallback_higher_is_better = true;
+};
+
+[[nodiscard]] std::string ModifierValueText(
+    const Modifier &mod, const Stat *stat = nullptr,
+    ModifierDisplayOptions options = {});
+
+/// Draws a single labeled modifier line. Returns false when there is no visible
+/// modifier value to display.
+bool ModifierLine(const char *label, const Modifier &mod,
+                  const Stat *stat = nullptr,
+                  ModifierDisplayOptions options = {});
+
 void StatTooltip(const Stat *stat);
 } // namespace Widgets

--- a/src/widgets/weather_widget.cpp
+++ b/src/widgets/weather_widget.cpp
@@ -3,23 +3,20 @@
 #include "modules/site/site.h"
 #include "modules/site/weather.h"
 #include "modules/stats/stats.h"
-#include <cctype>
+#include "widgets/stat_widget.h"
 
-static std::string formatStatName(const std::string &kebab) {
-  std::string result;
-  result.reserve(kebab.size());
-  bool nextUpper = true;
-  for (char c : kebab) {
-    if (c == '-') {
-      result += ' ';
-      nextUpper = true;
-    } else if (nextUpper) {
-      result += static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
-      nextUpper = false;
-    } else {
-      result += c;
-    }
+static Stat *findAffectedStat(flecs::entity root, const std::string &id) {
+  if (auto *stat = findStat(root, id)) {
+    return stat;
   }
+
+  Stat *result = nullptr;
+  root.children([&](flecs::entity child) {
+    if (result) {
+      return;
+    }
+    result = findAffectedStat(child, id);
+  });
   return result;
 }
 
@@ -62,13 +59,12 @@ void drawWeatherToolbarItem(flecs::world &world) {
           return;
         }
         const auto &mod = child.get<Modifier>();
-        if (mod.additive != 0.0) {
-          ImColor colour = (mod.additive > 0) ? ImColor(220, 80, 80, 255)
-                                              : ImColor(80, 200, 80, 255);
-          ImGui::Text("%s:", formatStatName(mod.target_stat).c_str());
-          ImGui::SameLine();
-          ImGui::TextColored(colour, "%+.0f%%", mod.additive * 100.0);
-        }
+        auto *stat = findAffectedStat(siteE, mod.target_stat);
+        const auto &label = stat ? stat->display() : mod.target_stat;
+        Widgets::ModifierLine(
+            label.c_str(), mod, stat,
+            {.fallback_format = Stat::Format::Percentage,
+             .fallback_higher_is_better = false});
       });
     }
 

--- a/src/widgets/weather_widget.cpp
+++ b/src/widgets/weather_widget.cpp
@@ -5,21 +5,6 @@
 #include "modules/stats/stats.h"
 #include "widgets/stat_widget.h"
 
-static Stat *findAffectedStat(flecs::entity root, const std::string &id) {
-  if (auto *stat = findStat(root, id)) {
-    return stat;
-  }
-
-  Stat *result = nullptr;
-  root.children([&](flecs::entity child) {
-    if (result) {
-      return;
-    }
-    result = findAffectedStat(child, id);
-  });
-  return result;
-}
-
 void drawWeatherToolbarItem(flecs::world &world) {
   static const char *placeholder = "\xef\x86\x85"; // fa-sun
 
@@ -59,12 +44,8 @@ void drawWeatherToolbarItem(flecs::world &world) {
           return;
         }
         const auto &mod = child.get<Modifier>();
-        auto *stat = findAffectedStat(siteE, mod.target_stat);
-        const auto &label = stat ? stat->display() : mod.target_stat;
-        Widgets::ModifierLine(
-            label.c_str(), mod, stat,
-            {.fallback_format = Stat::Format::Percentage,
-             .fallback_higher_is_better = false});
+        const auto definition = statDef(world, mod.target_stat);
+        Widgets::ModifierLine(definition.display.c_str(), mod, definition);
       });
     }
 

--- a/test/stats/stats.test.cpp
+++ b/test/stats/stats.test.cpp
@@ -4,30 +4,16 @@
 namespace {
 
 struct ReflectedStats {
-  Stat thrust{{.id = "thrust",
-               .display = "Thrust",
-               .description = "Engine thrust",
-               .base = 100.0}};
-  Stat cost{{.id = "cost",
-             .display = "Cost",
-             .description = "Build cost",
-             .base = 1000.0,
-             .higher_is_better = false,
-             .format = Stat::Format::Currency}};
-  Stat hidden{{.id = "hidden",
-               .display = "Hidden",
-               .description = "Not reflected",
-               .base = 5.0}};
+  Stat thrust{{.id = "thrust", .base = 100.0}};
+  Stat cost{{.id = "cost", .base = 1000.0}};
+  Stat hidden{{.id = "hidden", .base = 5.0}};
 };
 
 } // namespace
 
 SCENARIO("Stats", "[stats]") {
   GIVEN("A test stat with value 10") {
-    Stat stat{{.id = "test_stat",
-               .display = "Displ",
-               .description = "More Text",
-               .base = 10.0}};
+    Stat stat{{.id = "test_stat", .base = 10.0}};
 
     THEN("The base value is 10") { REQUIRE(stat.base() == 10.0); }
 
@@ -115,45 +101,85 @@ SCENARIO("Reflected stat registry", "[stats]") {
 
       THEN("the reflected stat pointer is returned") {
         REQUIRE(stat != nullptr);
-        CHECK(stat->display() == "Cost");
+        CHECK(stat->id() == "cost");
       }
     }
   }
 }
 
+SCENARIO("Stat definitions", "[stats]") {
+  flecs::world world;
+  world.import <StatsModule>();
+
+  GIVEN("the stats module is imported") {
+    THEN("StatDef and its format enum are reflected") {
+      const auto statDef = world.component<StatDef>();
+      const auto statFormat = world.component<StatDef::Format>();
+
+      CHECK(statDef.has<EcsStruct>());
+      CHECK(statFormat.has<EcsEnum>());
+      CHECK(statFormat.lookup("Number").is_valid());
+      CHECK(statFormat.lookup("Currency").is_valid());
+      CHECK(statFormat.lookup("Percentage").is_valid());
+    }
+  }
+
+  GIVEN("a registered stat definition") {
+    registerStatDef(world, {.id = "failure-rate",
+                            .display = "Failure Rate",
+                            .description = "Chance of launch failure",
+                            .higher_is_better = false,
+                            .format = Stat::Format::Percentage});
+
+    THEN("it can be looked up without a live stat instance") {
+      const auto *definition = findStatDef(world, "failure-rate");
+      REQUIRE(definition != nullptr);
+      CHECK(definition->display == "Failure Rate");
+      CHECK(definition->higher_is_better == false);
+      CHECK(definition->formatValue(0.1) == "10%");
+    }
+  }
+
+  GIVEN("an unknown stat id") {
+    THEN("a default display definition is available") {
+      const auto definition = statDef(world, "modded-stat");
+      CHECK(definition.id == "modded-stat");
+      CHECK(definition.display == "modded-stat");
+      CHECK(definition.description.empty());
+    }
+  }
+}
+
 SCENARIO("Stat formatting", "[stats]") {
-  GIVEN("a default number stat") {
-    Stat stat{{.id = "count",
-               .display = "Count",
-               .description = "A plain number",
-               .base = 12.4}};
+  GIVEN("a default number stat definition") {
+    StatDef definition{.id = "count",
+                       .display = "Count",
+                       .description = "A plain number"};
 
     THEN("it formats as a rounded number") {
-      REQUIRE(stat.format(12.4) == "12");
+      REQUIRE(definition.formatValue(12.4) == "12");
     }
   }
 
-  GIVEN("a currency stat") {
-    Stat stat{{.id = "cost",
-               .display = "Cost",
-               .description = "A money value",
-               .base = 1'250,
-               .format = Stat::Format::Currency}};
+  GIVEN("a currency stat definition") {
+    StatDef definition{.id = "cost",
+                       .display = "Cost",
+                       .description = "A money value",
+                       .format = Stat::Format::Currency};
 
     THEN("it formats with a dollar prefix and separators") {
-      REQUIRE(stat.format(1250) == "$1,250");
+      REQUIRE(definition.formatValue(1250) == "$1,250");
     }
   }
 
-  GIVEN("a percentage stat") {
-    Stat stat{{.id = "failure-rate",
-               .display = "Failure Rate",
-               .description = "A probability",
-               .base = 0.1,
-               .format = Stat::Format::Percentage}};
+  GIVEN("a percentage stat definition") {
+    StatDef definition{.id = "failure-rate",
+                       .display = "Failure Rate",
+                       .description = "A probability",
+                       .format = Stat::Format::Percentage};
 
     THEN("it formats probabilities as whole percentages") {
-      REQUIRE(stat.format(stat.base()) == "10%");
+      REQUIRE(definition.formatValue(0.1) == "10%");
     }
   }
 }

--- a/test/stats/stats.test.cpp
+++ b/test/stats/stats.test.cpp
@@ -1,6 +1,27 @@
 #include "modules/stats/stats.h"
 #include <catch2/catch_test_macros.hpp>
 
+namespace {
+
+struct ReflectedStats {
+  Stat thrust{{.id = "thrust",
+               .display = "Thrust",
+               .description = "Engine thrust",
+               .base = 100.0}};
+  Stat cost{{.id = "cost",
+             .display = "Cost",
+             .description = "Build cost",
+             .base = 1000.0,
+             .higher_is_better = false,
+             .format = Stat::Format::Currency}};
+  Stat hidden{{.id = "hidden",
+               .display = "Hidden",
+               .description = "Not reflected",
+               .base = 5.0}};
+};
+
+} // namespace
+
 SCENARIO("Stats", "[stats]") {
   GIVEN("A test stat with value 10") {
     Stat stat{{.id = "test_stat",
@@ -43,6 +64,58 @@ SCENARIO("Stats", "[stats]") {
       THEN("The result is again 10") {
         REQUIRE(result == false);
         REQUIRE(stat.value() == 10.0);
+      }
+    }
+  }
+}
+
+SCENARIO("Reflected stat registry", "[stats]") {
+  flecs::world world;
+  world.import <StatsModule>();
+
+  world.component<ReflectedStats>()
+      .member("thrust", &ReflectedStats::thrust)
+      .member("cost", &ReflectedStats::cost);
+
+  GIVEN("an entity with a reflected stats component and matching effects") {
+    auto source = world.entity("Source");
+    auto effect = world.entity("Engine Upgrade").add<Effect>();
+    world.entity()
+        .child_of(effect)
+        .set<Modifier>(
+            {.target_stat = "thrust", .additive = 25.0, .multiplicative = 1.0});
+    world.entity()
+        .child_of(effect)
+        .set<Modifier>(
+            {.target_stat = "cost", .additive = 250.0, .multiplicative = 1.0});
+    source.add<HasEffect>(effect);
+
+    auto entity = world.entity("Vehicle").child_of(source).set<ReflectedStats>(
+        {});
+
+    WHEN("the world progresses") {
+      world.progress();
+
+      THEN("all reflected stats receive their modifiers automatically") {
+        const auto &stats = entity.get<ReflectedStats>();
+        CHECK(stats.thrust.value() == 125.0);
+        CHECK(stats.cost.value() == 1250.0);
+      }
+
+      THEN("unregistered stat members are not discovered") {
+        const auto &stats = entity.get<ReflectedStats>();
+        CHECK(stats.hidden.value() == 5.0);
+        CHECK(findStat(entity, "hidden") == nullptr);
+      }
+    }
+
+    WHEN("a stat is found by id") {
+      world.progress();
+      auto *stat = findStat(entity, "cost");
+
+      THEN("the reflected stat pointer is returned") {
+        REQUIRE(stat != nullptr);
+        CHECK(stat->display() == "Cost");
       }
     }
   }

--- a/test/stats/stats.test.cpp
+++ b/test/stats/stats.test.cpp
@@ -1,4 +1,5 @@
 #include "modules/stats/stats.h"
+#include "widgets/stat_widget.h"
 #include <catch2/catch_test_macros.hpp>
 
 namespace {
@@ -66,18 +67,14 @@ SCENARIO("Reflected stat registry", "[stats]") {
   GIVEN("an entity with a reflected stats component and matching effects") {
     auto source = world.entity("Source");
     auto effect = world.entity("Engine Upgrade").add<Effect>();
-    world.entity()
-        .child_of(effect)
-        .set<Modifier>(
-            {.target_stat = "thrust", .additive = 25.0, .multiplicative = 1.0});
-    world.entity()
-        .child_of(effect)
-        .set<Modifier>(
-            {.target_stat = "cost", .additive = 250.0, .multiplicative = 1.0});
+    world.entity().child_of(effect).set<Modifier>(
+        {.target_stat = "thrust", .additive = 25.0, .multiplicative = 1.0});
+    world.entity().child_of(effect).set<Modifier>(
+        {.target_stat = "cost", .additive = 250.0, .multiplicative = 1.0});
     source.add<HasEffect>(effect);
 
-    auto entity = world.entity("Vehicle").child_of(source).set<ReflectedStats>(
-        {});
+    auto entity =
+        world.entity("Vehicle").child_of(source).set<ReflectedStats>({});
 
     WHEN("the world progresses") {
       world.progress();
@@ -152,9 +149,8 @@ SCENARIO("Stat definitions", "[stats]") {
 
 SCENARIO("Stat formatting", "[stats]") {
   GIVEN("a default number stat definition") {
-    StatDef definition{.id = "count",
-                       .display = "Count",
-                       .description = "A plain number"};
+    StatDef definition{
+        .id = "count", .display = "Count", .description = "A plain number"};
 
     THEN("it formats as a rounded number") {
       REQUIRE(definition.formatValue(12.4) == "12");
@@ -180,6 +176,46 @@ SCENARIO("Stat formatting", "[stats]") {
 
     THEN("it formats probabilities as whole percentages") {
       REQUIRE(definition.formatValue(0.1) == "10%");
+    }
+  }
+}
+
+SCENARIO("Modifier presentation", "[stats]") {
+  StatDef numberDef{.id = "capacity", .display = "Capacity"};
+  StatDef percentDef{.id = "failure-rate",
+                     .display = "Failure Rate",
+                     .format = Stat::Format::Percentage};
+
+  GIVEN("an additive number modifier") {
+    Modifier mod{.target_stat = "capacity", .additive = 5.0};
+
+    THEN("it is formatted with a sign") {
+      CHECK(Widgets::ModifierValueText(mod, numberDef) == "+5");
+    }
+  }
+
+  GIVEN("an additive percentage modifier") {
+    Modifier mod{.target_stat = "failure-rate", .additive = 0.25};
+
+    THEN("it is formatted using the stat definition") {
+      CHECK(Widgets::ModifierValueText(mod, percentDef) == "+25%");
+    }
+  }
+
+  GIVEN("a multiplicative modifier") {
+    Modifier mod{.target_stat = "capacity", .multiplicative = 1.2};
+
+    THEN("it is formatted as a relative percentage") {
+      CHECK(Widgets::ModifierValueText(mod, numberDef) == "+20%");
+    }
+  }
+
+  GIVEN("an invalid mixed additive and multiplicative modifier") {
+    Modifier mod{
+        .target_stat = "capacity", .additive = 5.0, .multiplicative = 1.2};
+
+    THEN("the additive part is presented as the modifier value") {
+      CHECK(Widgets::ModifierValueText(mod, numberDef) == "+5");
     }
   }
 }


### PR DESCRIPTION
Previously each stat had to be registered again after the flecs and lua registrations to be able to accumulate modifiers. Several were already skipped, highlighting the issue. Additionally, from a modifier, it was impossible to find a given Stat, which affected the Weather widget.

- All `Stat`s are now just an identifier and a base value
- A `StatDef` can be registered for display purposes, but if not set will be defaulted
- Stats can be centrally looked up 
- Modifier accumulation for entities is now registered automatically for each stat in each component
- This should work out of the box for stats created in lua code